### PR TITLE
Move tests to new classes & fix SessionKeysTest

### DIFF
--- a/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacket.java
+++ b/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacket.java
@@ -1504,16 +1504,6 @@ public class RequestPacket extends PaxosPacket implements Request,
 		checkMyFields();
 	}
 
-	public static class RequestPacketTest extends DefaultTest {
-		public RequestPacketTest() {
-		}
-
-		@Test
-		public void testCheckFields() {
-			doubleCheckFields();
-		}
-	}
-
 	static {
 		if (Config.getGlobalBoolean(PC.ENABLE_STATIC_CHECKS))
 			doubleCheckFields();

--- a/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacketTest.java
+++ b/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacketTest.java
@@ -1,0 +1,17 @@
+package edu.umass.cs.gigapaxos.paxospackets;
+
+import edu.umass.cs.utils.DefaultTest;
+import org.junit.Test;
+
+/**
+ * Created by kanantharamu on 2/20/17.
+ */
+public class RequestPacketTest extends DefaultTest {
+    public RequestPacketTest() {
+    }
+
+    @Test
+    public void testCheckFields() {
+        RequestPacket.doubleCheckFields();
+    }
+}

--- a/src/edu/umass/cs/gigapaxos/paxosutil/E2ELatencyAwareRedirector.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/E2ELatencyAwareRedirector.java
@@ -2,24 +2,17 @@ package edu.umass.cs.gigapaxos.paxosutil;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 import edu.umass.cs.gigapaxos.interfaces.NearestServerSelector;
-import edu.umass.cs.utils.DefaultTest;
 import edu.umass.cs.utils.Util;
 
 /**
@@ -143,121 +136,6 @@ public class E2ELatencyAwareRedirector implements NearestServerSelector {
 					break;
 				}
 		return match;
-	}
-
-	/**
-	 *
-	 */
-	public static class E2ELatencyAwareRedirectorTest extends DefaultTest {
-		final E2ELatencyAwareRedirector redirector;
-
-		/**
-		 * 
-		 */
-		public E2ELatencyAwareRedirectorTest() {
-			redirector = new E2ELatencyAwareRedirector();
-		}
-
-		/**
-		 * 
-		 */
-		@Test
-		public void test_PrefixMatchLength() {
-			try {
-				InetAddress addr1 = InetAddress.getByName("128.119.245.38");
-				Assert.assertEquals(32, prefixMatch(addr1, addr1));
-				Assert.assertEquals(
-						27,
-						prefixMatch(addr1,
-								InetAddress.getByName("128.119.245.48")));
-				Assert.assertEquals(
-						28,
-						prefixMatch(addr1,
-								InetAddress.getByName("128.119.245.47")));
-				Assert.assertEquals(
-						12,
-						prefixMatch(addr1,
-								InetAddress.getByName("128.120.245.47")));
-				Assert.assertEquals(
-						1,
-						prefixMatch(addr1,
-								InetAddress.getByName("255.120.245.47")));
-			} catch (UnknownHostException e) {
-				e.printStackTrace();
-			}
-		}
-
-		/**
-		 * 
-		 */
-		@Test
-		public void test_Learning() {
-			ConcurrentHashMap<InetSocketAddress, Long> groundTruth = new ConcurrentHashMap<InetSocketAddress, Long>();
-			ConcurrentHashMap<InetSocketAddress, Integer> redirections = new ConcurrentHashMap<InetSocketAddress, Integer>();
-			int n = 10;
-			int base = 2000;
-			// set up ground truth
-			for (int i = 0; i < n; i++)
-				groundTruth.put(new InetSocketAddress("127.0.0.1", base + i),
-						(long) (4 * i + 5));
-			// learn
-			int samples = 100;
-			for (int j = 0; j < samples; j++) {
-				InetSocketAddress isa = this.redirector.getNearest(groundTruth
-						.keySet());
-				redirections
-						.put(isa,
-								redirections.containsKey(isa) ? redirections
-										.get(isa) + 1 : 0);
-
-				this.redirector.learnSample(isa, groundTruth.get(isa)
-						* (1 + 0.1 * (Math.random() < 0.5 ? 1 : -1)));
-			}
-			for (InetSocketAddress isa : groundTruth.keySet())
-				System.out.println(isa
-						+ ": truth="
-						+ groundTruth.get(isa)
-						+ "; learned="
-						+ (this.redirector.e2eLatencies.containsKey(isa) ? Util
-								.df(this.redirector.e2eLatencies.get(isa))
-								: "null") + "; samples="
-						+ redirections.get(isa));
-		}
-
-		/**
-		 * 
-		 */
-		@Test
-		public void test_ProbeAndClosest() {
-			int n = 10;
-			int base = 2000;
-			InetSocketAddress[] addresses = new InetSocketAddress[n];
-			for (int i = 0; i < n; i++)
-				addresses[i] = new InetSocketAddress("127.0.0.1", base + i);
-			Set<InetSocketAddress> set1 = new HashSet<InetSocketAddress>(
-					Arrays.asList(addresses[1], addresses[2], addresses[3]));
-			redirector.learnSample(addresses[1],
-					(addresses[1].getPort() - base) * 10);
-			InetSocketAddress closest;
-			System.out.println("closest="
-					+ (closest = redirector.getNearest(set1)) + " "
-					+ redirector.e2eLatencies.get(closest) + "ms");
-			int tries = 1000, yesCount = 0;
-			for (int i = 0; i < tries; i++) {
-				InetSocketAddress isa = null;
-				yesCount += ((isa = redirector.getNearest(set1))
-						.equals(addresses[1])) ? 1 : 0;
-				redirector.learnSample(isa, (isa.getPort() - base) * 10);
-			}
-			// factor 2 is for some safety but can still be exceeded
-			String result = "expected=" + tries * (1 - PROBE_RATIO)
-					+ "; found=" + yesCount;
-			String allOK = " [all okay]";
-			String failure = " [difference is too big, which is possible but unlikely]";
-			Assert.assertTrue(result + failure, (yesCount > tries
-					* (1 - 2 * PROBE_RATIO)));
-			System.out.println(result + allOK);
-		}
 	}
 
 	/**

--- a/src/edu/umass/cs/gigapaxos/paxosutil/E2ELatencyAwareRedirectorTest.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/E2ELatencyAwareRedirectorTest.java
@@ -1,0 +1,129 @@
+package edu.umass.cs.gigapaxos.paxosutil;
+
+import edu.umass.cs.utils.DefaultTest;
+import edu.umass.cs.utils.Util;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ */
+public class E2ELatencyAwareRedirectorTest extends DefaultTest {
+    final E2ELatencyAwareRedirector redirector;
+
+    /**
+     *
+     */
+    public E2ELatencyAwareRedirectorTest() {
+        redirector = new E2ELatencyAwareRedirector();
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void test_PrefixMatchLength() {
+        try {
+            InetAddress addr1 = InetAddress.getByName("128.119.245.38");
+            Assert.assertEquals(32, E2ELatencyAwareRedirector.prefixMatch(addr1, addr1));
+            Assert.assertEquals(
+                    27,
+                    E2ELatencyAwareRedirector.prefixMatch(addr1,
+                            InetAddress.getByName("128.119.245.48")));
+            Assert.assertEquals(
+                    28,
+                    E2ELatencyAwareRedirector.prefixMatch(addr1,
+                            InetAddress.getByName("128.119.245.47")));
+            Assert.assertEquals(
+                    12,
+                    E2ELatencyAwareRedirector.prefixMatch(addr1,
+                            InetAddress.getByName("128.120.245.47")));
+            Assert.assertEquals(
+                    1,
+                    E2ELatencyAwareRedirector.prefixMatch(addr1,
+                            InetAddress.getByName("255.120.245.47")));
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void test_Learning() {
+        ConcurrentHashMap<InetSocketAddress, Long> groundTruth = new ConcurrentHashMap<InetSocketAddress, Long>();
+        ConcurrentHashMap<InetSocketAddress, Integer> redirections = new ConcurrentHashMap<InetSocketAddress, Integer>();
+        int n = 10;
+        int base = 2000;
+        // set up ground truth
+        for (int i = 0; i < n; i++)
+            groundTruth.put(new InetSocketAddress("127.0.0.1", base + i),
+                    (long) (4 * i + 5));
+        // learn
+        int samples = 100;
+        for (int j = 0; j < samples; j++) {
+            InetSocketAddress isa = this.redirector.getNearest(groundTruth
+                    .keySet());
+            redirections
+                    .put(isa,
+                            redirections.containsKey(isa) ? redirections
+                                    .get(isa) + 1 : 0);
+
+            this.redirector.learnSample(isa, groundTruth.get(isa)
+                    * (1 + 0.1 * (Math.random() < 0.5 ? 1 : -1)));
+        }
+        for (InetSocketAddress isa : groundTruth.keySet())
+            System.out.println(isa
+                    + ": truth="
+                    + groundTruth.get(isa)
+                    + "; learned="
+                    + (this.redirector.e2eLatencies.containsKey(isa) ? Util
+                            .df(this.redirector.e2eLatencies.get(isa))
+                            : "null") + "; samples="
+                    + redirections.get(isa));
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void test_ProbeAndClosest() {
+        int n = 10;
+        int base = 2000;
+        InetSocketAddress[] addresses = new InetSocketAddress[n];
+        for (int i = 0; i < n; i++)
+            addresses[i] = new InetSocketAddress("127.0.0.1", base + i);
+        Set<InetSocketAddress> set1 = new HashSet<InetSocketAddress>(
+                Arrays.asList(addresses[1], addresses[2], addresses[3]));
+        redirector.learnSample(addresses[1],
+                (addresses[1].getPort() - base) * 10);
+        InetSocketAddress closest;
+        System.out.println("closest="
+                + (closest = redirector.getNearest(set1)) + " "
+                + redirector.e2eLatencies.get(closest) + "ms");
+        int tries = 1000, yesCount = 0;
+        for (int i = 0; i < tries; i++) {
+            InetSocketAddress isa = null;
+            yesCount += ((isa = redirector.getNearest(set1))
+                    .equals(addresses[1])) ? 1 : 0;
+            redirector.learnSample(isa, (isa.getPort() - base) * 10);
+        }
+        // factor 2 is for some safety but can still be exceeded
+        String result = "expected=" + tries * (1 - E2ELatencyAwareRedirector.PROBE_RATIO)
+                + "; found=" + yesCount;
+        String allOK = " [all okay]";
+        String failure = " [difference is too big, which is possible but unlikely]";
+        Assert.assertTrue(result + failure, (yesCount > tries
+                * (1 - 2 * E2ELatencyAwareRedirector.PROBE_RATIO)));
+        System.out.println(result + allOK);
+    }
+}

--- a/src/edu/umass/cs/nio/nioutils/RTTEstimator.java
+++ b/src/edu/umass/cs/nio/nioutils/RTTEstimator.java
@@ -209,47 +209,6 @@ public class RTTEstimator {
 		return addrToInt(address) >>> 8; // logical, not artihmetic, shift
 	}
 
-	/**
-	 * RTTEstimator test class.
-	 */
-	static public class RTTEstimatorTest extends DefaultTest {
-		/**
-		 * @throws UnknownHostException
-		 */
-		@Test
-		public void testToInt() throws UnknownHostException {
-			InetAddress addr = InetAddress.getByName("128.119.245.38");
-			System.out.print((addr) + ": toInt=" + addrToInt(addr)
-					+ " ; toPrefixInt=" + addrToPrefixInt(addr));
-
-		}
-
-		/**
-		 * @throws UnknownHostException
-		 */
-		@Test
-		public void testRecord() throws UnknownHostException {
-			InetAddress addr = InetAddress.getByName("128.119.245.38");
-			record(addr, 2);
-			Assert.assertEquals(2, getRTT(addr));
-			record(addr, 4);
-			Assert.assertEquals(2, getRTT(addr));
-			record(addr, 10);
-			Assert.assertEquals(4, getRTT(addr));
-			System.out.print(getRTT(addr) + " ");
-
-			record(addr, 10);
-			System.out.print(getRTT(addr) + " ");
-
-			record(addr, 10);
-			System.out.print(getRTT(addr) + " ");
-
-			record(addr, 10);
-			System.out.print(getRTT(addr) + " ");
-			Assert.assertEquals(7, getRTT(addr));
-		}
-	}
-
 	private static LinkedHashMap<InetAddress, Long> testMap = new LinkedHashMap<InetAddress, Long>() {
 		/**
 		 * 

--- a/src/edu/umass/cs/nio/nioutils/RTTEstimatorTest.java
+++ b/src/edu/umass/cs/nio/nioutils/RTTEstimatorTest.java
@@ -1,0 +1,49 @@
+package edu.umass.cs.nio.nioutils;
+
+import edu.umass.cs.utils.DefaultTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * RTTEstimator test class.
+ */
+public class RTTEstimatorTest extends DefaultTest {
+    /**
+     * @throws UnknownHostException
+     */
+    @Test
+    public void testToInt() throws UnknownHostException {
+        InetAddress addr = InetAddress.getByName("128.119.245.38");
+        System.out.print((addr) + ": toInt=" + RTTEstimator.addrToInt(addr)
+                + " ; toPrefixInt=" + RTTEstimator.addrToPrefixInt(addr));
+
+    }
+
+    /**
+     * @throws UnknownHostException
+     */
+    @Test
+    public void testRecord() throws UnknownHostException {
+        InetAddress addr = InetAddress.getByName("128.119.245.38");
+        RTTEstimator.record(addr, 2);
+        Assert.assertEquals(2, RTTEstimator.getRTT(addr));
+        RTTEstimator.record(addr, 4);
+        Assert.assertEquals(2, RTTEstimator.getRTT(addr));
+        RTTEstimator.record(addr, 10);
+        Assert.assertEquals(4, RTTEstimator.getRTT(addr));
+        System.out.print(RTTEstimator.getRTT(addr) + " ");
+
+        RTTEstimator.record(addr, 10);
+        System.out.print(RTTEstimator.getRTT(addr) + " ");
+
+        RTTEstimator.record(addr, 10);
+        System.out.print(RTTEstimator.getRTT(addr) + " ");
+
+        RTTEstimator.record(addr, 10);
+        System.out.print(RTTEstimator.getRTT(addr) + " ");
+        Assert.assertEquals(7, RTTEstimator.getRTT(addr));
+    }
+}

--- a/src/edu/umass/cs/utils/SessionKeys.java
+++ b/src/edu/umass/cs/utils/SessionKeys.java
@@ -101,6 +101,8 @@ public class SessionKeys {
 	 */
 	protected static final String pkPair = "RSA/ECB/PKCS1Padding";
 
+	protected static final String keyPairAlgorithm = "RSA";
+
 	/**
 	 * A secret key certificate consists of a [secretKey, timestamp] 2-tuple
 	 * signed by the corresponding public key, and all three of these together
@@ -206,7 +208,7 @@ public class SessionKeys {
 			if (bbuf.hasRemaining()) {
 				byte[] encodedPublicKey = new byte[bbuf.getShort()];
 				bbuf.get(encodedPublicKey);
-				publicKey = KeyFactory.getInstance(pkPair).generatePublic(
+				publicKey = KeyFactory.getInstance(keyPairAlgorithm).generatePublic(
 						new X509EncodedKeySpec(encodedPublicKey));
 			} else
 				throw new RuntimeException(

--- a/src/edu/umass/cs/utils/SessionKeysTest.java
+++ b/src/edu/umass/cs/utils/SessionKeysTest.java
@@ -31,13 +31,16 @@ public class SessionKeysTest extends DefaultTest {
 	 * @throws SignatureException
 	 * @throws InvalidKeyException
 	 */
+
+
+
 	@Test
 	public void test_SignVerifySecretKey() throws NoSuchAlgorithmException,
 			InvalidKeyException, SignatureException,
 			UnsupportedEncodingException, IllegalBlockSizeException,
 			BadPaddingException, NoSuchPaddingException {
 		Util.assertAssertionsEnabled();
-		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.pkPair)
+		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.keyPairAlgorithm)
 				.genKeyPair();
 		SecretKey sk = SessionKeys.getOrGenerateSecretKey(keyPair.getPublic(),
 				keyPair.getPrivate());
@@ -64,7 +67,7 @@ public class SessionKeysTest extends DefaultTest {
 			InvalidKeyException, SignatureException,
 			UnsupportedEncodingException, IllegalBlockSizeException,
 			BadPaddingException, NoSuchPaddingException {
-		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.pkPair)
+		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.keyPairAlgorithm)
 				.genKeyPair();
 		SecretKey sk = SessionKeys.getOrGenerateSecretKey(keyPair.getPublic(),
 				keyPair.getPrivate());
@@ -87,7 +90,7 @@ public class SessionKeysTest extends DefaultTest {
 			UnsupportedEncodingException, IllegalBlockSizeException,
 			BadPaddingException, NoSuchPaddingException,
 			InvalidKeySpecException {
-		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.pkPair)
+		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.keyPairAlgorithm)
 				.genKeyPair();
 		SecretKey secretKey = SessionKeys.getOrGenerateSecretKey(
 				keyPair.getPublic(), keyPair.getPrivate());
@@ -120,7 +123,7 @@ public class SessionKeysTest extends DefaultTest {
 			UnsupportedEncodingException, IllegalBlockSizeException,
 			BadPaddingException, NoSuchPaddingException,
 			InvalidKeySpecException {
-		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.pkPair)
+		KeyPair keyPair = KeyPairGenerator.getInstance(SessionKeys.keyPairAlgorithm)
 				.genKeyPair();
 		SecretKey secretKey = SessionKeys.getOrGenerateSecretKey(
 				keyPair.getPublic(), keyPair.getPrivate());

--- a/src/edu/umass/cs/utils/Util.java
+++ b/src/edu/umass/cs/utils/Util.java
@@ -896,44 +896,4 @@ public class Util {
 		return null;
 	}
 
-	public static class UtilTest extends DefaultTest {
-		/**
-		 * @throws JSONException
-		 */
-		@SuppressWarnings("unchecked")
-		@Test
-		public void test_01_JSONObjectToMap() throws JSONException {
-			Util.assertAssertionsEnabled();
-			Map<String, ?> map = (JSONObjectToMap(new JSONObject()
-					.put("hello", "world")
-					.put("collField", Arrays.asList("hello", "world", 123))
-					.put("jsonField", new JSONObject().put("foo", true))));
-			System.out.println(map);
-			org.junit.Assert.assertTrue(map.get("jsonField") instanceof Map
-					&& (Boolean) ((Map<String, ?>) map.get("jsonField"))
-							.get("foo"));
-
-		}
-
-		/**
-		 * @throws JSONException
-		 */
-		@SuppressWarnings("unchecked")
-		@Test
-		public void test_01_JSONArrayToMap() throws JSONException {
-			Util.assertAssertionsEnabled();
-			List<?> list = (JSONArrayToList(new JSONArray()
-
-			.put("hello") // 0
-
-					.put(Arrays.asList("hello", "world", 123)) // 1
-
-					.put(new JSONObject().put("foo", true)))); // 2
-
-			System.out.println(list);
-			org.junit.Assert.assertTrue(list.get(2) instanceof Map
-					&& (Boolean) ((Map<String, ?>) list.get(2)).get("foo"));
-
-		}
-	}
 }

--- a/src/edu/umass/cs/utils/UtilTest.java
+++ b/src/edu/umass/cs/utils/UtilTest.java
@@ -1,0 +1,51 @@
+package edu.umass.cs.utils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class UtilTest extends DefaultTest {
+    /**
+     * @throws JSONException
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_01_JSONObjectToMap() throws JSONException {
+        Util.assertAssertionsEnabled();
+        Map<String, ?> map = (Util.JSONObjectToMap(new JSONObject()
+                .put("hello", "world")
+                .put("collField", Arrays.asList("hello", "world", 123))
+                .put("jsonField", new JSONObject().put("foo", true))));
+        System.out.println(map);
+        org.junit.Assert.assertTrue(map.get("jsonField") instanceof Map
+                && (Boolean) ((Map<String, ?>) map.get("jsonField"))
+                .get("foo"));
+
+    }
+
+    /**
+     * @throws JSONException
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_01_JSONArrayToMap() throws JSONException {
+        Util.assertAssertionsEnabled();
+        List<?> list = (Util.JSONArrayToList(new JSONArray()
+
+                .put("hello") // 0
+
+                .put(Arrays.asList("hello", "world", 123)) // 1
+
+                .put(new JSONObject().put("foo", true)))); // 2
+
+        System.out.println(list);
+        org.junit.Assert.assertTrue(list.get(2) instanceof Map
+                && (Boolean) ((Map<String, ?>) list.get(2)).get("foo"));
+
+    }
+}


### PR DESCRIPTION
Few tests written as inner classes are taken out in this change. They extend `DefaultTest` which causes almost everything to be included. Moving them out removes the dependency on DefaultTest. 