### PR TITLE
iOS changes - fixing compile time errors

### DIFF
--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -45,7 +45,7 @@ import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
 import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
-import edu.umass.cs.gigapaxos.interfaces.Shutdownable;
+import edu.umass.cs.gigapaxos.interfaces.GigapaxosShutdownable;
 import edu.umass.cs.gigapaxos.paxospackets.AcceptPacket;
 import edu.umass.cs.gigapaxos.paxospackets.AcceptReplyPacket;
 import edu.umass.cs.gigapaxos.paxospackets.BatchedPaxosPacket;
@@ -1614,7 +1614,7 @@ public class PaxosManager<NodeIDType> {
 		this.ppBatcher.stop();
 		this.largeCheckpointer.close();
 		this.executor.shutdownNow();
-		if(this.myApp instanceof Shutdownable) ((Shutdownable)this.myApp).shutdown();
+		if(this.myApp instanceof GigapaxosShutdownable) ((GigapaxosShutdownable)this.myApp).shutdown();
 
 		for (Iterator<PaxosInstanceStateMachine> pismIter = this.pinstances
 				.concurrentIterator(); pismIter.hasNext();)

--- a/src/edu/umass/cs/gigapaxos/interfaces/GigapaxosShutdownable.java
+++ b/src/edu/umass/cs/gigapaxos/interfaces/GigapaxosShutdownable.java
@@ -4,7 +4,7 @@ package edu.umass.cs.gigapaxos.interfaces;
  * @author arun
  *
  */
-public interface Shutdownable {
+public interface GigapaxosShutdownable {
 	/**
 	 * 
 	 */

--- a/src/edu/umass/cs/gigapaxos/paxospackets/PaxosPacket.java
+++ b/src/edu/umass/cs/gigapaxos/paxospackets/PaxosPacket.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.logging.Level;
 
 import edu.umass.cs.gigapaxos.PaxosConfig;
+import edu.umass.cs.utils.Util;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -480,7 +481,7 @@ public abstract class PaxosPacket extends JSONPacket implements Summarizable {
 
 		// copy over child fields
 		JSONObject child = toJSONObjectImpl();
-		for (String name : JSONObject.getNames(child))
+		for (String name : Util.getNames(child))
 			json.put(name, child.get(name));
 
 		return json;

--- a/src/edu/umass/cs/nio/AbstractNIOSSL.java
+++ b/src/edu/umass/cs/nio/AbstractNIOSSL.java
@@ -271,9 +271,9 @@ public abstract class AbstractNIOSSL implements Runnable {
 					new Object[] { this });
 			int biggerSize = engine.getSession().getApplicationBufferSize()
 					+ wrapDst.capacity();
-			if (biggerSize > MAX_DST_BUFFER_SIZE)
+			//if (biggerSize > MAX_DST_BUFFER_SIZE)
 				// throw new IllegalStateException("failed to wrap")
-				;
+			//	;
 			// try increasing buffer size up to maximum limit
 			if (biggerSize < MAX_DST_BUFFER_SIZE) {
 				wrapDst = getBiggerBuffer(wrapDst, biggerSize);
@@ -372,9 +372,10 @@ public abstract class AbstractNIOSSL implements Runnable {
 					new Object[] { this });
 			int biggerSize = engine.getSession().getApplicationBufferSize()
 					+ unwrapDst.capacity();
-			if (biggerSize > MAX_BUFFER_SIZE)
+			//iOS translation does not allow empty body "if" statements
+			//if (biggerSize > MAX_BUFFER_SIZE)
 				// throw new IllegalStateException("failed to unwrap")
-				;
+			//	;
 			// try increasing size first
 			if (biggerSize < MAX_BUFFER_SIZE) {
 				unwrapDst = getBiggerBuffer(unwrapDst, biggerSize);

--- a/src/edu/umass/cs/reconfiguration/AbstractReplicaCoordinator.java
+++ b/src/edu/umass/cs/reconfiguration/AbstractReplicaCoordinator.java
@@ -32,7 +32,7 @@ import edu.umass.cs.gigapaxos.interfaces.AppRequestParserBytes;
 import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
-import edu.umass.cs.gigapaxos.interfaces.Shutdownable;
+import edu.umass.cs.gigapaxos.interfaces.GigapaxosShutdownable;
 import edu.umass.cs.gigapaxos.paxospackets.PaxosPacket;
 import edu.umass.cs.gigapaxos.paxospackets.RequestPacket;
 import edu.umass.cs.nio.GenericMessagingTask;
@@ -466,8 +466,8 @@ public abstract class AbstractReplicaCoordinator<NodeIDType> implements
 
 	public void stop() {
 		this.messenger.stop();
-		if(this.app instanceof Shutdownable)
-			((Shutdownable)this.app).shutdown();
+		if(this.app instanceof GigapaxosShutdownable)
+			((GigapaxosShutdownable)this.app).shutdown();
 	}
 
 	/********************** Request propagation helper methods ******************/

--- a/src/edu/umass/cs/reconfiguration/PaxosReplicaCoordinator.java
+++ b/src/edu/umass/cs/reconfiguration/PaxosReplicaCoordinator.java
@@ -27,7 +27,7 @@ import edu.umass.cs.gigapaxos.PaxosManager;
 import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
-import edu.umass.cs.gigapaxos.interfaces.Shutdownable;
+import edu.umass.cs.gigapaxos.interfaces.GigapaxosShutdownable;
 import edu.umass.cs.gigapaxos.paxosutil.PaxosInstanceCreationException;
 import edu.umass.cs.gigapaxos.paxosutil.StringContainer;
 import edu.umass.cs.nio.JSONMessenger;
@@ -317,7 +317,7 @@ public class PaxosReplicaCoordinator<NodeIDType> extends
 		this.messenger.stop();
 		this.paxosManager.close();
 
-		if(this.app instanceof Shutdownable)
-			((Shutdownable)this.app).shutdown();
+		if(this.app instanceof GigapaxosShutdownable)
+			((GigapaxosShutdownable)this.app).shutdown();
 	}
 }

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -127,9 +127,10 @@ public class ReconfigurationConfig {
 				edu.umass.cs.reconfiguration.examples.noopsimple.NoopApp.class
 						.getName()),
 		/**
-		 * Demand profile class name.
+		 * Demand profile class name. iOS client requires that this name be specified as a string
+		 * as opposed to using class.getName()
 		 */
-		DEMAND_PROFILE_TYPE(DemandProfile.class.getName()),
+		DEMAND_PROFILE_TYPE("edu.umass.cs.reconfiguration.reconfigurationutils.DemandProfile"),
 
 		/**
 		 * Directory where reconfiguration DB is maintained when an embedded DB

--- a/src/edu/umass/cs/reconfiguration/reconfigurationutils/TrivialRepliconfigurable.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationutils/TrivialRepliconfigurable.java
@@ -24,7 +24,7 @@ import edu.umass.cs.gigapaxos.interfaces.AppRequestParserBytes;
 import edu.umass.cs.gigapaxos.interfaces.Application;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
-import edu.umass.cs.gigapaxos.interfaces.Shutdownable;
+import edu.umass.cs.gigapaxos.interfaces.GigapaxosShutdownable;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.nio.nioutils.NIOHeader;
 import edu.umass.cs.reconfiguration.interfaces.Reconfigurable;
@@ -34,7 +34,7 @@ import edu.umass.cs.reconfiguration.interfaces.Repliconfigurable;
 /**
 @author V. Arun
  */
-public class TrivialRepliconfigurable implements Repliconfigurable, AppRequestParserBytes, Shutdownable {
+public class TrivialRepliconfigurable implements Repliconfigurable, AppRequestParserBytes, GigapaxosShutdownable {
 	
 	/**
 	 * The underlying app.
@@ -141,7 +141,7 @@ public class TrivialRepliconfigurable implements Repliconfigurable, AppRequestPa
 	}
 	
 	public void shutdown() {
-		if(this.app instanceof Shutdownable)
-			((Shutdownable)this.app).shutdown();
+		if(this.app instanceof GigapaxosShutdownable)
+			((GigapaxosShutdownable)this.app).shutdown();
 	}
 }

--- a/src/edu/umass/cs/utils/Util.java
+++ b/src/edu/umass/cs/utils/Util.java
@@ -826,13 +826,34 @@ public class Util {
 		return list;
 	}
 
+	/**
+	 * Get an array of field names from a JSONObject.
+	 * COPIED from org.json - Android's moving this method to util to preserve
+	 * Android and iOS compatibility.
+	 * @return An array of field names, or null if there are no names.
+	 */
+	public static String[] getNames(JSONObject jo) {
+		int length = jo.length();
+		if (length == 0) {
+			return null;
+		}
+		Iterator iterator = jo.keys();
+		String[] names = new String[length];
+		int i = 0;
+		while (iterator.hasNext()) {
+			names[i] = (String) iterator.next();
+			i += 1;
+		}
+		return names;
+	}
+
 	/* This method converts a JSONObject to a Map<String,?> while recursively
 	 * converting the values to JSONObject or JSONArray as needed. */
 	public static Map<String, ?> JSONObjectToMap(JSONObject json)
 			throws JSONException {
 		if (json == null)
 			return null;
-		String[] keys = JSONObject.getNames(json);
+		String[] keys = getNames(json);
 		if (keys != null) {
 			Map<String, Object> map = new HashMap<String, Object>();
 			for (String key : keys)


### PR DESCRIPTION
Changes:

- Rename `Shutdownable` to `GigapaxosShutdownable` to avoid name conflict with GNS' `Shutdownable`
- Avoid usage of `JSON.getNames()` to make gigapaxos compatible with Android's and j2objc's `org.json`
- Remove a couple of empty body "if" statements (unsupported by j2objc)
- Avoid usage of `DemandProfile.class.getName()` as it is not supported by j2objc. Replace it with a fully qualified class name instead