### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 # sudo: required instructs Travis to use a "real VM" instead of a docker VM
 sudo: required
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -qq ant-optional
 jdk:
 - oraclejdk8
 notifications:


### PR DESCRIPTION
This change installs ant tools explicitly which is no longer being offered in the latest Travis CI build environment.