### PR TITLE
ReconfiguratorAsyncClient pull request

### DIFF
--- a/src/edu/umass/cs/reconfiguration/ReconfigurableAppClientAsync.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurableAppClientAsync.java
@@ -1344,7 +1344,7 @@ public abstract class ReconfigurableAppClientAsync<V> implements
 			if ((activesInfo = this.activeReplicas.get(ALL_ACTIVES)) != null
 					&& (actives = activesInfo.actives) != null
 					&& this.queriedActivesRecently(ALL_ACTIVES))
-				return this.sendRequest(request, actives.iterator().next(),
+				return this.sendRequest(request, (InetSocketAddress)Util.selectRandom(actives),
 						callback);
 			// else
 			RequestCallbackFuture<V> future;


### PR DESCRIPTION
Selecting an active replica randomly for anycast compared to the previous implementation that always chose the first in the list. Even if the reconfigurator shuffles the list of actives, the actives list is cached for few seconds so we cannot always choose to send an anycast request to the first active replica in the list. I missed this change in the last pull request related to this.