### PR TITLE
Fix for an assertion error in SQLPaxosLogger

### DIFF
--- a/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java
+++ b/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java
@@ -3159,6 +3159,9 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 	private void garbageCollectJournal(TreeSet<Filename> candidates) {
 		// long t = System.currentTimeMillis();
 		// first get file list, then live list
+		if(candidates == null || candidates.size() == 0)
+				return ;
+		
 		if (SQLPaxosLogger.this.journaler.numOngoingGCs++ > 0)
 			log.severe(this + " has "
 					+ SQLPaxosLogger.this.journaler.numOngoingGCs


### PR DESCRIPTION
In this pull request, I have included a possible fix for the following assertion error. This 
[assertion](https://github.com/MobilityFirst/gigapaxos/blob/master/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java#L3261) fails because [this](https://github.com/MobilityFirst/gigapaxos/blob/master/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java#L828) can return an empty set. So, I have added a check [here](https://github.com/MobilityFirst/gigapaxos/pull/28/files#diff-cf348c73a870bce826c684f4f9a68590R3162).

java.lang.AssertionError
    at edu.umass.cs.gigapaxos.SQLPaxosLogger.getActiveLogfilesFromCheckpointTable(SQLPaxosLogger.java:3261)
    at edu.umass.cs.gigapaxos.SQLPaxosLogger.garbageCollectJournal(SQLPaxosLogger.java:3169)
    at edu.umass.cs.gigapaxos.SQLPaxosLogger.access$14(SQLPaxosLogger.java:3159)
    at edu.umass.cs.gigapaxos.SQLPaxosLogger$4.run(SQLPaxosLogger.java:1059)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
