### PR TITLE
Add IOSSSLDataProcessingWorker 

### DIFF
--- a/src/edu/umass/cs/nio/IOSSSLDataProcessingWorker.java
+++ b/src/edu/umass/cs/nio/IOSSSLDataProcessingWorker.java
@@ -1,0 +1,361 @@
+/* Copyright (c) 2015 University of Massachusetts
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ * 
+ * Initial developer(s): V. Arun */
+package edu.umass.cs.nio;
+
+import edu.umass.cs.nio.interfaces.DataProcessingWorker;
+import edu.umass.cs.nio.interfaces.HandshakeCallback;
+import edu.umass.cs.nio.interfaces.InterfaceMessageExtractor;
+import edu.umass.cs.nio.nioutils.NIOInstrumenter;
+import edu.umass.cs.utils.Util;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author arun
+ *
+ *         This class does SSL wrap/unwrap functions respectively right before
+ *         NIO performs an (unencrypted) outgoing network write and right after
+ *         NIO receives (encrypted) incoming network reads. It is really not a
+ *         "message extractor", just an InterfaceDataProcessingWorker + wrap
+ *         functionality, but it implements InterfaceMessageExtractor so that it
+ *         is easy for MessageNIOTransport to conduct its functions without
+ *         worrying about whether NIOTransport.worker is
+ *         InterfaceMessageExtractor or not.
+ * 
+ *         Nevertheless, this class can be used simply with NIOTransport for
+ *         secure byte stream communication as InterfaceMessageExtractor is also
+ *         an InterfaceDataProcessingWorker.
+ */
+public class IOSSSLDataProcessingWorker implements InterfaceMessageExtractor {
+
+
+	// to handle incoming decrypted data
+	private final DataProcessingWorker decryptedWorker;
+
+	private final ExecutorService taskWorkers = Executors.newFixedThreadPool(4);
+
+	private ConcurrentHashMap<SelectableChannel, AbstractNIOSSL> sslMap = new ConcurrentHashMap<SelectableChannel, AbstractNIOSSL>();
+
+	// to signal connection handshake completion to transport
+	private HandshakeCallback callbackTransport = null;
+
+	protected final SSLDataProcessingWorker.SSL_MODES sslMode;
+
+	private String myID = null;
+	private static final Logger log = NIOTransport.getLogger();
+
+	/**
+	 * @param worker
+	 * @param sslMode
+	 * @throws NoSuchAlgorithmException
+	 * @throws SSLException
+	 */
+	protected IOSSSLDataProcessingWorker(DataProcessingWorker worker,
+                                         SSLDataProcessingWorker.SSL_MODES sslMode, String myID)
+			throws NoSuchAlgorithmException, SSLException {
+		this.decryptedWorker = worker;
+		this.sslMode = sslMode;
+		this.myID = myID;
+	}
+
+	protected IOSSSLDataProcessingWorker setHandshakeCallback(
+			HandshakeCallback callback) {
+		this.callbackTransport = callback;
+		return this;
+	}
+
+	@Override
+	public void processData(SocketChannel channel, ByteBuffer encrypted) {
+		AbstractNIOSSL nioSSL = this.sslMap.get(channel);
+		assert (nioSSL != null);
+		log.log(Level.FINEST,
+				"{0} received encrypted data of length {1} bytes to send on channel {2}",
+				new Object[] { this, encrypted.remaining(),
+						channel });
+		// unwrap SSL
+		nioSSL.notifyReceived(encrypted);
+		assert (encrypted.remaining() == 0); // else buffer overflow exception
+	}
+
+	// invoke SSL wrap
+	protected int wrap(SocketChannel channel, ByteBuffer unencrypted) {
+		AbstractNIOSSL nioSSL = this.sslMap.get(channel);
+		assert (nioSSL != null);
+		log.log(Level.FINEST,
+				"{0} wrapping unencrypted data of length {1} bytes to send on channel {2}",
+				new Object[] { this, unencrypted.remaining(), channel });
+		int originalSize = unencrypted.remaining();
+		try {
+			nioSSL.nioSend(unencrypted);
+		} catch (BufferOverflowException | IllegalStateException e) {
+			// do nothing, sender will automatically slow down
+			e.printStackTrace();
+		}
+		return originalSize - unencrypted.remaining();
+	}
+
+	protected boolean isHandshakeComplete(SocketChannel socketChannel) {
+		AbstractNIOSSL nioSSL = this.sslMap.get(socketChannel);
+		// socketChannel may be unmapped yet or under exception
+		return nioSSL != null ? ((NonBlockingSSLImpl) nioSSL)
+				.isHandshakeComplete() : false;
+	}
+
+	protected boolean register(SelectionKey key, boolean isClient)
+			throws IOException {
+		assert (!this.sslMap.containsKey(key.channel()));
+		SSLEngine engine;
+		try {
+			engine = SSLContext.getDefault().createSSLEngine();
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException(e.getMessage());
+		}
+		engine.setUseClientMode(isClient);
+		if (this.sslMode.equals(SSLDataProcessingWorker.SSL_MODES.MUTUAL_AUTH))
+			engine.setNeedClientAuth(true);
+		engine.beginHandshake();
+		log.log(Level.FINE,
+				"{0} registered {1} socket channel {2}",
+				new Object[] { this, (isClient ? "client" : "server"),
+						key.channel() });
+		this.sslMap.put(key.channel(), new NonBlockingSSLImpl(key, engine,
+				 this.taskWorkers));
+		return true;
+	}
+
+	protected void poke() {
+		for (AbstractNIOSSL nioSSL : this.sslMap.values()) {
+			nioSSL.poke();
+		}
+	}
+
+	// remove entry from sslMap, no need to check containsKey
+	private void cleanup(SelectionKey key) {
+		NIOTransport.cleanup(key);
+		this.remove(key);
+	}
+	
+	// called by cleanup in NIOTransport
+	protected void remove(SelectionKey key) {
+		SocketChannel socketChannel = (SocketChannel) key.channel();
+		if (socketChannel != null) {
+			AbstractNIOSSL nioSSL = this.sslMap.remove(socketChannel);
+			if(nioSSL!=null) nioSSL.clean(); // quicker GC of byte buffers
+		}
+	}
+
+	// SSL NIO implementation
+	class NonBlockingSSLImpl extends AbstractNIOSSL {
+		final SSLEngine engine;
+		private boolean handshakeComplete = false;
+
+		NonBlockingSSLImpl(SelectionKey key, SSLEngine engine,
+				 Executor taskWorkers) {
+			super(key, engine, taskWorkers, IOSSSLDataProcessingWorker.this.myID);
+			this.engine = engine;
+		}
+
+		// inbound decrypted data is simply handed over to worker
+		@Override
+		public void onInboundData(ByteBuffer decrypted) {
+			log.log(Level.FINEST,
+					"{0} received decrypted data of length {1} bytes on channel {2}",
+					new Object[] { this, decrypted.remaining(), ((SocketChannel) (key.channel())) });
+			IOSSSLDataProcessingWorker.this.extractMessages(key, decrypted);
+		}
+
+		@Override
+		public void onHandshakeFailure(Exception cause) {
+			cause.printStackTrace();
+			log.log(Level.WARNING,
+					"{0} encountered SSL handshake failure; cleaning up channel {1}",
+					new Object[] { this, key.channel() });
+			// should only be invoked by selection thread
+			cleanup(key);
+		}
+
+		@Override
+		public void onHandshakeSuccess() {
+			this.setHandshakeComplete();
+			log.log(Level.FINE,
+					"{0} conducted successful SSL handshake for channel {1}",
+					new Object[] { this, key.channel() });
+		}
+
+		@Override
+		public void onClosed() {
+			log.log(Level.FINE, "{0} cleaning up closed SSL channel {1}",
+					new Object[] { this, key.channel() });
+			cleanup(key);
+		}
+
+		@Override
+		public void onOutboundData(ByteBuffer encrypted) {
+			SocketChannel channel = ((SocketChannel) key.channel());
+			try {
+				log.log(Level.FINEST,
+						"{0} sending encrypted data of length {1} bytes to send on channel {2}",
+						new Object[] { this, encrypted.remaining(),
+								channel });
+				/* The assertion is true because we initialized key in the
+				 * parent constructor. This method is the only reason we need
+				 * the key in the parent, otherwise AbstractNIOSSL is just an
+				 * SSL template and has nothing to do with NIO. */
+				assert (key != null);
+				int totalLength = encrypted.remaining();
+				/* Try few times, but can't really wait here except in case
+				 * of handshaking when we have to send everything out.
+				 */
+				for (int attempts = 0; (attempts < 1 || !this
+						.isHandshakeComplete()) && encrypted.hasRemaining(); attempts++)
+					channel.write(encrypted);
+
+				NIOInstrumenter.incrEncrBytesSent(totalLength - encrypted.remaining());
+
+				// not a showstopper if we don't absolutely complete the write
+				if (encrypted.hasRemaining())
+					log.log(Level.FINE,
+							"{0} failed to bulk-write {1} bytes despite multiple attempts ({2} bytes left unsent)",
+							new Object[] { this, totalLength,
+									encrypted.remaining(), });
+
+			} catch (IOException | IllegalStateException exc) {
+				// need to cleanup as we are screwed
+				log.severe(this + " ran into " + exc.getClass().getSimpleName()
+						+ "  while writing outbound data; closing channel");
+				cleanup(key);
+				throw new IllegalStateException(exc);
+			}
+		}
+
+		public String toString() {
+			return this.getClass().getSimpleName() + getMyID();
+		}
+
+		private synchronized boolean isHandshakeComplete() {
+			return this.handshakeComplete;
+		}
+
+		private synchronized void setHandshakeComplete() {
+			this.handshakeComplete = true;
+			callbackTransport.handshakeComplete(this.key);
+		}
+	}
+
+	public String toString() {
+		return this.getClass().getSimpleName() + getMyID();
+	}
+
+	/**
+	 * @return My ID, primarily for logging purposes.
+	 */
+	public String getMyID() {
+		return this.myID;
+	}
+
+	protected void setMyID(String id) {
+		this.myID = id;
+	}
+
+	public void stop() {
+		this.taskWorkers.shutdownNow();
+		if (this.decryptedWorker instanceof InterfaceMessageExtractor)
+			((InterfaceMessageExtractor) this.decryptedWorker).stop();
+	}
+
+	@Override
+	public void addPacketDemultiplexer(AbstractPacketDemultiplexer<?> pd) {
+		if (this.decryptedWorker instanceof InterfaceMessageExtractor)
+			((InterfaceMessageExtractor) this.decryptedWorker)
+					.addPacketDemultiplexer(pd);
+	}
+	@Override
+	public void precedePacketDemultiplexer(AbstractPacketDemultiplexer<?> pd) {
+		if (this.decryptedWorker instanceof InterfaceMessageExtractor)
+			((InterfaceMessageExtractor) this.decryptedWorker)
+					.precedePacketDemultiplexer(pd);
+	}
+
+	@Override
+	public void processLocalMessage(InetSocketAddress sockAddr, byte[] msg) {
+		if (this.decryptedWorker instanceof InterfaceMessageExtractor)
+			((InterfaceMessageExtractor) this.decryptedWorker)
+					.processLocalMessage(sockAddr, msg);
+
+	}
+
+	private void extractMessages(SelectionKey key, ByteBuffer incoming) {
+		ByteBuffer bbuf = null;
+		try {
+			while (incoming.hasRemaining()
+					&& (bbuf = this.extractMessage(key, incoming)) != null) {
+				this.decryptedWorker.processData((SocketChannel) key.channel(),
+						bbuf);
+			}
+		} catch (IOException e) {
+			log.severe(this + e.getMessage() + " on channel " + key.channel());
+			e.printStackTrace();
+			// incoming is emptied out; what else to do here?
+		}
+	}
+
+	// extracts a single message
+	private ByteBuffer extractMessage(SelectionKey key, ByteBuffer incoming)
+			throws IOException {
+		NIOTransport.AlternatingByteBuffer abbuf = (NIOTransport.AlternatingByteBuffer) key
+				.attachment();
+		assert (abbuf != null);
+		if (abbuf.headerBuf.remaining() > 0) {
+			Util.put(abbuf.headerBuf, incoming);
+//			abbuf.readHeader(incoming);
+			if (abbuf.headerBuf.remaining() == 0) {
+				abbuf.bodyBuf = ByteBuffer.allocate(NIOTransport
+						.getPayloadLength((ByteBuffer) abbuf.headerBuf.flip()));
+				assert (abbuf.bodyBuf != null && abbuf.bodyBuf.capacity() > 0);
+			}
+		}
+		ByteBuffer retval = null;
+		if (abbuf.bodyBuf != null) {
+			Util.put(abbuf.bodyBuf, incoming);
+			if (abbuf.bodyBuf.remaining() == 0) {
+				retval = (ByteBuffer) abbuf.bodyBuf.flip();
+				abbuf.clear(); // prepare for next read
+			}
+		}
+		return retval;
+	}
+
+	@Override
+	public void demultiplexMessage(Object message) {
+		this.decryptedWorker.demultiplexMessage(message);
+	}
+}

--- a/src/edu/umass/cs/nio/NIOTransport.java
+++ b/src/edu/umass/cs/nio/NIOTransport.java
@@ -543,7 +543,7 @@ public class NIOTransport<NodeIDType> implements Runnable, HandshakeCallback {
 				// set ops to CONNECT for pending connect requests.
 				processPendingConnects();
 				// wait for an event one of the registered channels.
-				int num = this.selector.select(SELECT_TIMEOUT);
+				this.selector.select(SELECT_TIMEOUT);
 				// accept, connect, read, or write as needed.
 				processSelectedKeys();
 				// process data from pending buffers on congested channels
@@ -646,9 +646,11 @@ public class NIOTransport<NodeIDType> implements Runnable, HandshakeCallback {
 		(this.selector.selectedKeys());
 		Iterator<SelectionKey> selectedKeys = selected.iterator();
 		//Collections.shuffle(selected); // to mix in reads and writes
+
 		while (selectedKeys.hasNext()) {
 			SelectionKey key = (SelectionKey) selectedKeys.next();
 			selectedKeys.remove();
+
 			if (!key.isValid()) {
 				//cleanup(key, (AbstractSelectableChannel) key.channel());
 				cleanupSSL(key);
@@ -824,6 +826,7 @@ public class NIOTransport<NodeIDType> implements Runnable, HandshakeCallback {
 
 	private void read(SelectionKey key) throws IOException {
 		SocketChannel socketChannel = (SocketChannel) key.channel();
+
 		// if SSL, simply pass any bytes to SSL worker
 		if (isSSL() && !IS_IOS) {
 			this.readBuffers.putIfAbsent(key,


### PR DESCRIPTION
Add IOSSSLDataProcessingWorker for SSL support in translated iOS code. This change only modifies `NIOTransport` and mostly uses empty methods in `IOSSSLDataProcessingWorker`. The translated `IOSSSLDataProcessingWorker` will be replaced by `IOSSSLDataProcessingWorker.m` in the GNSClients_ios repository. The java source for `IOSSSLDataProcessingWorker` also contains embedded objective C source so that after translation, calling native methods becomes trivial.