### PR TITLE
Fixed nooppaxos example port typo

### DIFF
--- a/conf/examples/nooppaxos.properties
+++ b/conf/examples/nooppaxos.properties
@@ -11,5 +11,5 @@ active.AR2=127.0.0.1:2002
 # format: reconfigurator.<active_server_name>=host:port
 reconfigurator.RC0=127.0.0.1:3000
 reconfigurator.RC1=127.0.0.1:3001
-reconfigurator.RC2=127.0.0.1:r002
+reconfigurator.RC2=127.0.0.1:3002
 


### PR DESCRIPTION
Running the server with this example caused a runtime exception when parsing the port number