### PR TITLE
Patch to support transactions

### DIFF
--- a/conf/gigapaxos.properties
+++ b/conf/gigapaxos.properties
@@ -2,7 +2,7 @@
 #APPLICATION=edu.umass.cs.reconfiguration.examples.noopsimple.NoopApp
 #APPLICATION=edu.umass.cs.gigapaxos.examples.noop.NoopPaxosApp
 
-GIGAPAXOS_DATA_DIR=tmp/gigapaxos
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
 
 # format: active.<active_server_name>=host:port
 active.AR0=127.0.0.1:2000

--- a/conf/gigapaxos.properties
+++ b/conf/gigapaxos.properties
@@ -2,7 +2,7 @@
 #APPLICATION=edu.umass.cs.reconfiguration.examples.noopsimple.NoopApp
 #APPLICATION=edu.umass.cs.gigapaxos.examples.noop.NoopPaxosApp
 
-GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+GIGAPAXOS_DATA_DIR=tmp/gigapaxos
 
 # format: active.<active_server_name>=host:port
 active.AR0=127.0.0.1:2000

--- a/src/edu/umass/cs/reconfiguration/AbstractReplicaCoordinator.java
+++ b/src/edu/umass/cs/reconfiguration/AbstractReplicaCoordinator.java
@@ -191,8 +191,7 @@ public abstract class AbstractReplicaCoordinator<NodeIDType> implements
 		 * Reconfigurator sets the callback before its
 		 * getReconfigurableReconfiguratorAsActiveReplica.
 		 */
-		if (this.callback == null)
-			this.callback = callback;
+		this.callback = callback;
 		return this;
 	}
 
@@ -431,11 +430,12 @@ public abstract class AbstractReplicaCoordinator<NodeIDType> implements
 		return this.stopCallback != null
 				&& this.stopCallback.preRestore(name, state) ? true
 
-		:this.callback!=null &&this.callback.preRestore(name,state) ? true
 
 		/* Will be a no-op except during recovery when stopCallback will be null
 		 * as it wouldn't yet have been set. */
 		: this.preRestore(name, state) ? true
+
+		:this.callback!=null &&this.callback.preRestore(name,state) ? true
 
 		: app.restore(name, state);
 	}

--- a/src/edu/umass/cs/reconfiguration/ActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/ActiveReplica.java
@@ -158,7 +158,7 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 			ReconfigurableNodeConfig<NodeIDType> nodeConfig,
 			SSLMessenger<NodeIDType, ?> messenger, boolean noReporting) {
 		this.appCoordinator = (AbstractReplicaCoordinator<NodeIDType>)
-				wrapCoordinator(appC.setStopCallback(
+				(appC.setStopCallback(
 				// setting default callback is optional
 				// (ReconfiguratorCallback) this).setCallback(
 						(ReconfiguratorCallback) this));
@@ -191,28 +191,7 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 		// initInstrumenter();
 	}
 
-	protected static AbstractReplicaCoordinator<?> wrapCoordinator(
-			AbstractReplicaCoordinator<?> coordinator) {
-		Class<?> clazz = null;
-		try {
-			clazz = Class.forName(Config
-					.getGlobalString(RC.COORDINATOR_WRAPPER));
-		} catch (ClassNotFoundException e) {
-			// eat up exception, normal case
-		}
-		if (clazz == null)
-			return coordinator;
-		// reflectively instantiate
-		try {
-			return (AbstractReplicaCoordinator<?>) clazz.getConstructor(
-					AbstractReplicaCoordinator.class).newInstance(coordinator);
-		} catch (InstantiationException | IllegalAccessException
-				| IllegalArgumentException | InvocationTargetException
-				| NoSuchMethodException | SecurityException e) {
-			e.printStackTrace();
-		}
-		return coordinator;
-	}
+
 
 	/**
 	 * @param name

--- a/src/edu/umass/cs/reconfiguration/PaxosReplicaCoordinator.java
+++ b/src/edu/umass/cs/reconfiguration/PaxosReplicaCoordinator.java
@@ -34,6 +34,7 @@ import edu.umass.cs.nio.JSONMessenger;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.nio.interfaces.Messenger;
 import edu.umass.cs.nio.interfaces.Stringifiable;
+import edu.umass.cs.reconfiguration.interfaces.CoordinatorCallback;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
 import edu.umass.cs.reconfiguration.interfaces.ReplicableRequest;
 import edu.umass.cs.reconfiguration.reconfigurationpackets.ReconfigurationPacket;
@@ -61,8 +62,8 @@ public class PaxosReplicaCoordinator<NodeIDType> extends
 	private PaxosReplicaCoordinator(Replicable app, NodeIDType myID,
 			Stringifiable<NodeIDType> unstringer,
 			Messenger<NodeIDType, ?> niot, String paxosLogFolder,
-			boolean enableNullCheckpoints) {
-		super(app, niot);
+			boolean enableNullCheckpoints,CoordinatorCallback callback) {
+		super(app, niot,callback);
 		assert (niot instanceof JSONMessenger);
 		this.paxosManager = new PaxosManager<NodeIDType>(myID, unstringer,
 				(JSONMessenger<NodeIDType>) niot, this, paxosLogFolder,
@@ -72,7 +73,11 @@ public class PaxosReplicaCoordinator<NodeIDType> extends
 						.getNodePort(myID)), niot);
 	}
 
-
+	public PaxosReplicaCoordinator(Replicable app, NodeIDType myID,
+								   Stringifiable<NodeIDType> unstringer, Messenger<NodeIDType, ?> niot,
+										CoordinatorCallback<NodeIDType> coordinatorCallback) {
+		this(app, myID, unstringer, niot, null, true,coordinatorCallback);
+	}
 	/**
 	 * @param app
 	 * @param myID
@@ -81,7 +86,7 @@ public class PaxosReplicaCoordinator<NodeIDType> extends
 	 */
 	public PaxosReplicaCoordinator(Replicable app, NodeIDType myID,
 			Stringifiable<NodeIDType> unstringer, Messenger<NodeIDType, ?> niot) {
-		this(app, myID, unstringer, niot, null, true);
+		this(app, myID, unstringer, niot, null, true,null);
 	}
 
 	/**
@@ -95,7 +100,7 @@ public class PaxosReplicaCoordinator<NodeIDType> extends
 	public PaxosReplicaCoordinator(Replicable app, NodeIDType myID,
 			Stringifiable<NodeIDType> unstringer,
 			Messenger<NodeIDType, ?> niot, int outOfOrderLimit) {
-		this(app, myID, unstringer, (JSONMessenger<NodeIDType>) niot);
+		this(app, myID, unstringer, (JSONMessenger<NodeIDType>) niot,null);
 		assert (niot instanceof JSONMessenger);
 		this.paxosManager.setOutOfOrderLimit(outOfOrderLimit);
 	}

--- a/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
@@ -187,6 +187,7 @@ public abstract class ReconfigurableNode<NodeIDType> {
 	@SuppressWarnings("unchecked")
 	private CoordinatorCallback<NodeIDType> getWrappingCoordinatorCallback(){
 		Class<?> clazz = null;
+		if(!Config.getGlobalBoolean(ReconfigurationConfig.RC.ENABLE_TRANSACTIONS))return null;
 		try {
 			clazz = Class.forName(Config
 					.getGlobalString(ReconfigurationConfig.RC.COORDINATOR_WRAPPER));

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -288,7 +288,7 @@ public class ReconfigurationConfig {
 		 * that this parameter is irrelevant after name creation as the number
 		 * of replicas thereafter is controlled by the reconfiguration policy.
 		 */
-		REPLICATE_ALL(true),
+		REPLICATE_ALL(false),
 		/**
 		 * 
 		 */
@@ -385,13 +385,13 @@ public class ReconfigurationConfig {
 		/**
 		 * If true, transactions are enabled; else disabled.
 		 */
-		ENABLE_TRANSACTIONS (false),
+		ENABLE_TRANSACTIONS (true),
 		
 		/**
 		 * The name of the class used to wrap the application's default
 		 * coordinator.
 		 */
-		COORDINATOR_WRAPPER("edu.umass.cs.txn.DistTransactor"),
+		COORDINATOR_WRAPPER("edu.umass.cs.transaction.DistTransactor"),
 		
 		/**
 		 * 

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -385,7 +385,7 @@ public class ReconfigurationConfig {
 		/**
 		 * If true, transactions are enabled; else disabled.
 		 */
-		ENABLE_TRANSACTIONS (true),
+		ENABLE_TRANSACTIONS (false),
 		
 		/**
 		 * The name of the class used to wrap the application's default

--- a/src/edu/umass/cs/reconfiguration/interfaces/CoordinatorCallback.java
+++ b/src/edu/umass/cs/reconfiguration/interfaces/CoordinatorCallback.java
@@ -1,0 +1,16 @@
+package edu.umass.cs.reconfiguration.interfaces;
+
+import edu.umass.cs.gigapaxos.interfaces.AppRequestParser;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+import edu.umass.cs.nio.interfaces.Messenger;
+import edu.umass.cs.reconfiguration.AbstractReplicaCoordinator;
+
+import java.util.Set;
+
+public interface CoordinatorCallback<NodeIDType> extends ReconfiguratorCallback,AppRequestParser{
+
+    void setCoordinator(AbstractReplicaCoordinator<NodeIDType> coordinator,Messenger messenger);
+
+    Set<IntegerPacketType> getRequestTypes() ;
+
+}


### PR DESCRIPTION
Instead of DistTransactor being a wrapper around PRC. 
I have used DistTransactor to be a callback for the PRC.
We where partially using this in the preExecute case.
This patch treats the DistTransactor as a callback and nothing else.
Some modifications needed where 
1. The ARC has to register packets of the Callback
2. The Callback is set at time of initialization. 
This solves the problem of the PaxosManager trying to recover before the callback is set.

