### PR TITLE
Add HelloRequest to allow an active replica behind NAT to communicate with other actives

### DIFF
--- a/conf/examples/nat.properties
+++ b/conf/examples/nat.properties
@@ -1,0 +1,31 @@
+# default application is NoopApp
+# This configure file is used to show the option ENABLE_NAT allows 
+# an active replica to be able to communicate with other active replicas.
+# 
+# FIXME: use your own cloud instance IP address, it doesn't matter what 
+# IP address you use for the local active replica as long as you can
+# bind NIO to that IP address.
+# 
+# Command: 
+# bin/gpServer.sh -DgigapaxosConfig=conf/examples/nat.properties restart all
+# bin/gpClient.sh -DgigapaxosConfig=conf/examples/nat.properties edu.umass.cs.gigapaxos.examples.adder.StatefulAdderAppClient
+# 
+# Try set ENABLE_NAT=false and see whether the requests can get through
+
+APPLICATION=edu.umass.cs.gigapaxos.examples.adder.StatefulAdderApp
+
+ENABLE_NAT=true
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+# format: active.<active_server_name>=host:port
+# AR0 is an active replica on the cloud 
+active.AR0=128.110.153.102:2000
+# AR1 is an active replica behind an NAT
+active.AR1=192.168.24.226:2000
+
+# format: reconfigurator.<active_server_name>=host:port
+# RC0 is a reconfigurator on the cloud
+reconfigurator.RC0=128.110.153.102:3000
+
+# USERNAME=ubuntu

--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -2663,8 +2663,8 @@ public class PaxosManager<NodeIDType> {
 				this.myID, pp); // paxosID and version should be within
 		int nodeID = FindReplicaGroupPacket.getNodeID(pp);
 		NodeIDType node = nodeID > 0 ? this.integerMap.get(nodeID) : 
-				(pp instanceof RequestPacket ? 
-				this.integerMap.get(nodeID=((RequestPacket) pp).getEntryReplica())
+				(pp instanceof RequestPacket && (nodeID=((RequestPacket) pp).getEntryReplica()) > 0 ? 
+				this.integerMap.get(nodeID)
 				: null)
 				;
 		if (nodeID >= 0) {
@@ -2678,7 +2678,7 @@ public class PaxosManager<NodeIDType> {
 				ioe.printStackTrace();
 			}
 		} else if(!this.corpses.containsKey(pp.getPaxosID())) {
-			PaxosConfig.log.log(pp instanceof RequestPacket ? Level.WARNING : Level.INFO,
+			PaxosConfig.log.log(pp instanceof RequestPacket ? Level.INFO : Level.INFO,
 					"{0} cant find group member in {1} {2}",
 					new Object[] {
 							this,

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -388,6 +388,12 @@ public class ReconfigurationConfig {
 		ENABLE_TRANSACTIONS (false),
 		
 		/**
+		 * Enable {@HelloRequest} for an active running behind NAT
+		 * to be able to communicate to the other replicas
+		 */
+		ENABLE_NAT (false),
+		
+		/**
 		 * The name of the class used to wrap the application's default
 		 * coordinator.
 		 */

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/HelloRequest.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/HelloRequest.java
@@ -1,0 +1,95 @@
+package edu.umass.cs.reconfiguration.reconfigurationpackets;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
+import edu.umass.cs.nio.interfaces.Stringifiable;
+import edu.umass.cs.reconfiguration.ReconfigurationConfig.RC;
+import edu.umass.cs.utils.Config;
+
+/**
+ * @author gaozy
+ * 
+ * @param <NodeIDType> 
+ *
+ */
+public class HelloRequest<NodeIDType> extends BasicReconfigurationPacket<NodeIDType> 
+	implements ClientRequest {
+
+	private static enum Keys {
+		QID, ID
+	};
+	
+	/**
+	 * 
+	 */
+	public final long requestID;
+	
+	/**
+	 * 
+	 */
+	public final NodeIDType myID;
+	/**
+	 * 
+	 */
+	
+	/**
+	 * @param initiator
+	 */
+	public HelloRequest(NodeIDType initiator) {
+		super(initiator, 
+				ReconfigurationPacket.PacketType.HELLO_REQUEST, 
+				Config.getGlobalString(RC.BROADCAST_NAME), 0);
+		// this.addr = addr;
+		this.requestID = (long) (Math.random() * Long.MAX_VALUE);
+		this.myID = initiator;
+		
+	}
+
+	/**
+	 * @param json
+	 * @param unstringer
+	 * @throws JSONException
+	 * @throws UnknownHostException
+	 */
+	@SuppressWarnings("unchecked")
+	public HelloRequest(JSONObject json, Stringifiable<NodeIDType> unstringer)
+			throws JSONException, UnknownHostException {
+		super(json, unstringer);
+		
+		this.requestID = json.getLong(Keys.QID.toString());
+		this.myID = (NodeIDType) json.get(Keys.ID.toString());
+		/*
+		this.myReceiver = MessageNIOTransport.getReceiverAddress(json);
+		this.setSender(MessageNIOTransport.getSenderAddress(json));
+		this.sentTime = json.getLong(Keys.SENT_TIME.toString());
+		*/
+	}
+	
+	public JSONObject toJSONObjectImpl() throws JSONException {
+		JSONObject json = super.toJSONObjectImpl();
+		json.put(Keys.QID.toString(), this.requestID);
+		json.put(Keys.ID.toString(), this.myID);
+		
+		return json;
+	}
+	
+	@Override
+	public long getRequestID() {
+		return this.requestID;
+	}
+
+	@Override
+	public ClientRequest getResponse() {
+		return this;
+	}
+	
+	@Override
+	public InetSocketAddress getClientAddress() {
+		return null;
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/ReconfigurationPacket.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/ReconfigurationPacket.java
@@ -137,6 +137,9 @@ public abstract class ReconfigurationPacket<NodeIDType> extends
 		// client <-> active
 		REPLICABLE_CLIENT_REQUEST (242),
 		
+		// active -> active, or active -> reconfigurator: initialize a connection behind NAT
+		HELLO_REQUEST(243),
+		
 		NO_TYPE (999),
 		
 		;
@@ -218,6 +221,8 @@ public abstract class ReconfigurationPacket<NodeIDType> extends
 				EchoRequest.class);
 		typeMap.put(ReconfigurationPacket.PacketType.REPLICABLE_CLIENT_REQUEST,
 				ReplicableClientRequest.class);
+		typeMap.put(ReconfigurationPacket.PacketType.HELLO_REQUEST, 
+				HelloRequest.class);
 
 		for (ReconfigurationPacket.PacketType type : ReconfigurationPacket.PacketType.intToType
 				.values()) {

--- a/src/edu/umass/cs/reconfiguration/reconfigurationprotocoltasks/ActiveReplicaProtocolTask.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationprotocoltasks/ActiveReplicaProtocolTask.java
@@ -47,7 +47,8 @@ ProtocolTask<NodeIDType, ReconfigurationPacket.PacketType, String> {
 		ReconfigurationPacket.PacketType.START_EPOCH,
 		ReconfigurationPacket.PacketType.REQUEST_EPOCH_FINAL_STATE,
 		ReconfigurationPacket.PacketType.DROP_EPOCH_FINAL_STATE,
-		ReconfigurationPacket.PacketType.ECHO_REQUEST
+		ReconfigurationPacket.PacketType.ECHO_REQUEST,
+		ReconfigurationPacket.PacketType.HELLO_REQUEST
 	};
 	private static final ReconfigurationPacket.PacketType[] types = ReconfigurationPacket.concatenate(defaultTypes,
 		WaitEpochFinalState.types);

--- a/src/edu/umass/cs/reconfiguration/reconfigurationprotocoltasks/ReconfiguratorProtocolTask.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationprotocoltasks/ReconfiguratorProtocolTask.java
@@ -53,7 +53,11 @@ public class ReconfiguratorProtocolTask<NodeIDType> implements
 
 			// any node with ssl credentials -> reconfigurator
 			ReconfigurationPacket.PacketType.RECONFIGURE_RC_NODE_CONFIG,
-			ReconfigurationPacket.PacketType.RECONFIGURE_ACTIVE_NODE_CONFIG, };
+			ReconfigurationPacket.PacketType.RECONFIGURE_ACTIVE_NODE_CONFIG,
+	
+			// hello request for active replica to update its InetSocketAddress if it's behind NAT
+			ReconfigurationPacket.PacketType.HELLO_REQUEST
+	};
 	private static final ReconfigurationPacket.PacketType[] types = ReconfigurationPacket
 			.concatenate(localTypes, WaitAckStopEpoch.types,
 					WaitAckStartEpoch.types, WaitAckDropEpoch.types);


### PR DESCRIPTION
This pull request contains the following changes:
1. Add a feature to allow an active replica behind NAT to be able to communicate with other actives. 
2. Implement a request type HelloRequest.java for the active replica behind NAT to contact other replicas to initialize connections with the others.
3. Add an option ENABLE_NAT to enable the features described above. By default, this option is set to false.
4. Add a config file (conf/example/nat.properties) to test this feature.