### PR TITLE
Add an HTTP front end to ActiveReplica

### DIFF
--- a/conf/examples/http.properties
+++ b/conf/examples/http.properties
@@ -1,0 +1,12 @@
+APPLICATION=edu.umass.cs.reconfiguration.http.HttpActiveReplicaApp
+
+ENABLE_ACTIVE_REPLICA_HTTP=true
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+# format: active.<active_server_name>=host:port
+active.AR0=127.0.0.1:2000
+
+# format: reconfigurator.<active_server_name>=host:port
+reconfigurator.RC0=127.0.0.1:3000
+

--- a/src/edu/umass/cs/reconfiguration/ActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/ActiveReplica.java
@@ -202,18 +202,18 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 				// and this node is not a reconfigurator
 				&& !(nodeConfig.getActiveReplicas().contains(this.getMyID()))) {
 			final InetSocketAddress addr = new InetSocketAddress(messenger.getListeningSocketAddress().getAddress(),
-					ReconfigurationConfig.getHTTPPort(port));
+					ReconfigurationConfig.getHTTPPort( messenger.getListeningSocketAddress().getPort()) );
 			
 			this.protocolExecutor.submit(new Runnable() {
 				@Override
 				public void run() {
-					initHTTPServer(false);
+					initHTTPServer(false, addr);
 				}
 			});
 		}
 	}
 
-	private void initHTTPServer(boolean ssl){
+	private void initHTTPServer(boolean ssl, InetSocketAddress addr){
 		
 		try {
 			// initialize HTTP server
@@ -223,7 +223,8 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 			
 			// initialize 			
 			Class<?> c = Class.forName(httpActiveReplicaName);
-			c.getConstructor(edu.umass.cs.reconfiguration.interfaces.ActiveReplicaFunctions.class, boolean.class).newInstance(this, ssl);
+			c.getConstructor(edu.umass.cs.reconfiguration.interfaces.ActiveReplicaFunctions.class,  InetSocketAddress.class, boolean.class)
+			.newInstance(this, addr, ssl);
 		} catch (Exception e) {
 			if (!(e instanceof InterruptedException)) // close
 				e.printStackTrace();

--- a/src/edu/umass/cs/reconfiguration/ActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/ActiveReplica.java
@@ -200,9 +200,10 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 		// ENABLE_ACTIVE_REPLICA_HTTP is true
 		if (Config.getGlobalBoolean(RC.ENABLE_ACTIVE_REPLICA_HTTP) 
 				// and this node is not a reconfigurator
-				&& !(nodeConfig.getActiveReplicas().contains(this.getMyID()))) {
-			final InetSocketAddress addr = new InetSocketAddress(messenger.getListeningSocketAddress().getAddress(),
-					ReconfigurationConfig.getHTTPPort( messenger.getListeningSocketAddress().getPort()) );
+				&& !(nodeConfig.getReconfigurators().contains(this.getMyID()))) {
+			InetSocketAddress me = this.messenger.getListeningSocketAddress();
+			final InetSocketAddress addr = new InetSocketAddress(me.getAddress(),
+					ReconfigurationConfig.getHTTPPort( me.getPort()) );
 			
 			this.protocolExecutor.submit(new Runnable() {
 				@Override

--- a/src/edu/umass/cs/reconfiguration/ActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/ActiveReplica.java
@@ -24,6 +24,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +34,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.net.ssl.SSLException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -66,6 +69,8 @@ import edu.umass.cs.nio.nioutils.RTTEstimator;
 import edu.umass.cs.protocoltask.ProtocolExecutor;
 import edu.umass.cs.protocoltask.ProtocolTask;
 import edu.umass.cs.reconfiguration.ReconfigurationConfig.RC;
+import edu.umass.cs.reconfiguration.http.HttpActiveReplica;
+import edu.umass.cs.reconfiguration.interfaces.ActiveReplicaFunctions;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableAppInfo;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableNodeConfig;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
@@ -127,7 +132,7 @@ import edu.umass.cs.utils.UtilServer;
  *            active replica placement.
  */
 public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
-		PacketDemultiplexer<Request> {
+		PacketDemultiplexer<Request>, ActiveReplicaFunctions {
 	/**
 	 * Offset for client facing port that may in general be different from
 	 * server-to-server communication as we may need different transport-layer
@@ -190,12 +195,35 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 				AbstractReconfiguratorDB.RecordNames.AR_RC_NODES.toString(),
 				this.appCoordinator.getARRCNodesAsString());
 
-		 initInstrumenter();
+		initInstrumenter();
 		if (Config.getGlobalBoolean(ReconfigurationConfig.RC.ENABLE_NAT)) {
 			sendHelloRequest();
 		}
+		
+		// ENABLE_ACTIVE_REPLICA_HTTP is true
+		if (Config.getGlobalBoolean(RC.ENABLE_ACTIVE_REPLICA_HTTP) 
+				// and this node is not a reconfigurator
+				&& !(nodeConfig.getReconfigurators().contains(this.getMyID()))) {
+			this.protocolExecutor.submit(new Runnable() {
+				@Override
+				public void run() {
+					initHTTPServer(false);
+				}
+			});
+		}
 	}
 
+	private void initHTTPServer(boolean ssl){
+		
+		try {
+			new HttpActiveReplica(this, ssl);
+
+		} catch (CertificateException | InterruptedException | SSLException e) {
+			if (!(e instanceof InterruptedException)) // close
+				e.printStackTrace();
+		}	
+	}
+	
 	protected static AbstractReplicaCoordinator<?> wrapCoordinator(
 			AbstractReplicaCoordinator<?> coordinator) {
 		Class<?> clazz = null;
@@ -522,12 +550,13 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 	private static final String appName = ReconfigurationConfig.application
 			.getSimpleName();
 
-
+	
 	/**
 	 * The interval to send {@link HelloRequest} to update
 	 * the NIO socket address on the other replicas.
-	 */ 
-	private static final int helloRequestInterval = 10; // seconds	
+	 */
+	private static final int helloRequestInterval = 10; // seconds
+	
 	protected void sendHelloRequest() {
 		this.protocolExecutor.scheduleWithFixedDelay(
 				new HelloRunnable(messenger, nodeConfig), 0, helloRequestInterval, TimeUnit.SECONDS);
@@ -1601,5 +1630,21 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 						AbstractReconfiguratorDB.RecordNames.AR_RC_NODES.toString())
 //				|| request.getServiceName().equals(ReconfigurationConfig.getDefaultServiceName())
 				? true: false;
+	}
+
+	/**
+	 * A wrapper method for handRequestToApp, should only be used by {@link HttpActiveReplica}.
+	 */
+	@Override
+	public boolean handRequestToAppForHttp(Request request, ExecutedCallback callback) {
+		return handRequestToApp(request, callback);
+	}
+	
+	/**
+	 * A wrapper method for updateDemandStats, should only be used by {@link HttpActiveReplica}.
+	 */
+	@Override
+	public void updateDemandStatsFromHttp(Request request, InetAddress addr) {
+		updateDemandStats(request, addr);
 	}
 }

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -388,6 +388,11 @@ public class ReconfigurationConfig {
 		ENABLE_ACTIVE_REPLICA_HTTP(false),
 		
 		/**
+		 * HTTP active replica name
+		 */
+		HTTP_ACTIVE_REPLICA_NAME("edu.umass.cs.reconfiguration.http.HttpActiveReplica"),
+		
+		/**
 		 * If true, transactions are enabled; else disabled.
 		 */
 		ENABLE_TRANSACTIONS (false),

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -380,7 +380,12 @@ public class ReconfigurationConfig {
 		/**
 		 * Enable the HTTP server for reconfigurators.
 		 */
-		ENABLE_HTTP (true),
+		ENABLE_RECONFIGURATOR_HTTP (true),
+		
+		/**
+		 * Enable the HTTP server for active replicas
+		 */
+		ENABLE_ACTIVE_REPLICA_HTTP(false),
 		
 		/**
 		 * If true, transactions are enabled; else disabled.

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -212,7 +212,7 @@ public class Reconfigurator<NodeIDType> implements
 	}
 
 	private void initHTTPServer(boolean ssl) {
-		if (!Config.getGlobalBoolean(RC.ENABLE_HTTP))
+		if (!Config.getGlobalBoolean(RC.ENABLE_RECONFIGURATOR_HTTP))
 			return;
 		InetSocketAddress me = this.messenger.getListeningSocketAddress();
 		try {

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -60,7 +60,19 @@ import io.netty.util.CharsetUtil;
  * 
  * A similar implementation to {@link HttpReconfigurator}
  * 
+ * Example command:
+ * curl -X POST localhost:12416 -d '{NAME:"XDNApp0", QID:0, COORD: true, QVAL: "1", type: 400}' -H "Content-Type: application/json"
  * 
+ * Start ActiveReplica with HttpActiveReplica:
+ * java -ea -cp jars/gigapaxos-1.0.08.jar -Djava.util.logging.config.file=conf/logging.properties \
+ * -Dlog4j.configuration=conf/log4j.properties -Djavax.net.ssl.keyStorePassword=qwerty -Djavax.net.ssl.trustStorePassword=qwerty \
+ * -Djavax.net.ssl.keyStore=conf/keyStore.jks -Djavax.net.ssl.trustStore=conf/trustStore.jks \
+ * -DgigapaxosConfig=conf/xdn.local.properties -DHTTPADDR=127.0.0.1 -Dcontainer=localhost:3000 \
+ * edu.umass.cs.reconfiguration.ReconfigurableNode AR0
+ * 
+ * Start HttpActiveReplica alone:
+ * java -ea -cp jars/gigapaxos-1.0.08.jar -DHTTPADDR=127.0.0.1 -Dcontainer=localhost:3000 \
+ * edu.umass.cs.reconfiguration.http.HttpActiveReplica
  * 
  * @author gaozy
  *
@@ -187,7 +199,7 @@ public class HttpActiveReplica {
 		@Override
 		protected void initChannel(SocketChannel channel) throws Exception {
 			ChannelPipeline p = channel.pipeline();
-			
+			// TODO: test performance
 			if (sslCtx != null) 
 				p.addLast(sslCtx.newHandler(channel.alloc()));
 			

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -1,0 +1,389 @@
+package edu.umass.cs.reconfiguration.http;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ssl.SSLException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.reconfiguration.ReconfigurationConfig;
+import edu.umass.cs.reconfiguration.interfaces.ActiveReplicaFunctions;
+import edu.umass.cs.reconfiguration.reconfigurationpackets.ReplicableClientRequest;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.CharsetUtil;
+
+/**
+ * An HTTP front-end for an active replica that supports interaction
+ * between a http client and this front-end.
+ * To use this HTTP front-end, the underlying application use the request
+ * type {@link HttpActiveReplicaRequest} or a type that extends {@link HttpActiveReplicaRequest}.
+ * 
+ * Loosely based on the HTTP Snoop server example from netty
+ * documentation pages.
+ * 
+ * A similar implementation to {@link HttpReconfigurator}
+ * 
+ * 
+ * 
+ * @author gaozy
+ *
+ */
+public class HttpActiveReplica {
+	
+	private static final Logger log = ReconfigurationConfig.getLogger();
+	
+	private final static int NUM_BOSS_THREADS = 4;
+	
+	private final static int DEFAULT_HTTP_PORT = 12416;
+	private final static String DEFAULT_HTTP_ADDR = "localhost";
+	
+	private final static String HTTP_ADDR_ENV_KEY = "HTTPADDR";
+		
+	/**
+	 * Whether response needs to be sent back in a synchronized manner: 
+	 * true means response needs to be sent back after underlying app
+	 * has successfully executed the request, i.e., the response must
+	 * be sent back through {@link ExecutedCallback}; false means 
+	 * response can be sent back before the underlying app executes the
+	 * request.
+	 */
+	private final static String SYNC_KEY = "SYNC";
+	
+	private final EventLoopGroup bossGroup;
+	private final EventLoopGroup workerGroup;
+	
+	private final Channel channel;
+	
+	/**
+	 * @param arf
+	 * @param ssl
+	 * @throws CertificateException
+	 * @throws SSLException
+	 * @throws InterruptedException
+	 */
+	public HttpActiveReplica(ActiveReplicaFunctions arf,
+			boolean ssl) throws CertificateException, SSLException, InterruptedException {
+		this(arf, null, ssl);
+	}
+	
+	/**
+	 * @param arf
+	 * @param sockAddr
+	 * @param ssl
+	 * @throws CertificateException
+	 * @throws SSLException
+	 * @throws InterruptedException
+	 */
+	public HttpActiveReplica(ActiveReplicaFunctions arf,
+			InetSocketAddress sockAddr, boolean ssl) 
+			throws CertificateException, SSLException, InterruptedException {
+		
+		// Configure SSL.
+		final SslContext sslCtx;
+		if (ssl) {
+			SelfSignedCertificate ssc = new SelfSignedCertificate();
+			sslCtx = SslContextBuilder.forServer(ssc.certificate(),
+					ssc.privateKey()).build();
+		} else {
+			sslCtx = null;
+		}
+		
+		/**
+		 *  Configure the netty ServerBootstrap
+		 */
+		bossGroup = new NioEventLoopGroup(NUM_BOSS_THREADS);
+		workerGroup = new NioEventLoopGroup();
+		try {
+			ServerBootstrap b = new ServerBootstrap();
+			b.group(bossGroup, workerGroup)
+					.channel(NioServerSocketChannel.class)
+					.handler(new LoggingHandler(LogLevel.INFO))
+					.childHandler(
+							new HttpActiveReplicaInitializer(arf, sslCtx)
+							);
+
+			if (sockAddr == null) {
+				
+				String addr = DEFAULT_HTTP_ADDR;
+				int port = DEFAULT_HTTP_PORT;
+				
+				if (System.getProperty(HTTP_ADDR_ENV_KEY) != null) {
+					addr = System.getProperty(HTTP_ADDR_ENV_KEY);
+				}
+				sockAddr = new InetSocketAddress(addr, port);
+			}
+			
+			channel = b.bind(sockAddr).sync().channel();
+			
+			log.log(Level.INFO, "HttpActiveReplica is ready on {0}", new Object[] {sockAddr});
+			System.out.println( "HttpActiveReplica ready on "+sockAddr);
+
+			channel.closeFuture().sync();
+		} finally {
+			bossGroup.shutdownGracefully();
+			workerGroup.shutdownGracefully();
+		}
+		
+	}
+	
+	/**
+	 * Close server and workers gracefully.
+	 */
+	public void close() {
+		this.bossGroup.shutdownGracefully();
+		this.workerGroup.shutdownGracefully();
+	}	
+	
+	
+	private static class HttpActiveReplicaInitializer extends
+	ChannelInitializer<SocketChannel> {
+
+		private final SslContext sslCtx;
+		final ActiveReplicaFunctions arFunctions;
+		
+		HttpActiveReplicaInitializer(final ActiveReplicaFunctions arf,
+				SslContext sslCtx){
+			this.arFunctions = arf;
+			this.sslCtx = sslCtx;
+		}		
+		
+		@Override
+		protected void initChannel(SocketChannel channel) throws Exception {
+			ChannelPipeline p = channel.pipeline();
+			
+			if (sslCtx != null) 
+				p.addLast(sslCtx.newHandler(channel.alloc()));
+			
+			p.addLast(new HttpRequestDecoder());
+			
+			// Uncomment if you don't want to handle HttpChunks.
+			p.addLast(new HttpObjectAggregator(1048576));
+
+			p.addLast(new HttpResponseEncoder());
+
+			p.addLast(new HttpActiveReplicaHandler(arFunctions, channel.remoteAddress()));
+			
+		}
+		
+	}
+	
+	private static JSONObject getJSONObjectFromHttpContent(HttpContent httpContent){
+		ByteBuf content = httpContent.content();
+		byte[] bytes;
+		if (content.isReadable()) {
+	    	bytes = new byte[content.readableBytes()];
+	        content.readBytes(bytes);
+	        log.log(Level.FINE, "HttpContent: {0}", new Object[]{new String(bytes)});
+	        // System.out.println("Content:"+(new String(bytes)));
+	    } else {
+	    	return null;
+	    }
+			
+		try {
+			return new JSONObject(new String(bytes));
+			
+		} catch (JSONException e) {
+			return null;
+		}
+		
+	}
+	
+	private static void sendResponseAndCloseConnection(ChannelHandlerContext ctx) {		
+		FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, BAD_REQUEST,
+				Unpooled.copiedBuffer("".toString(), CharsetUtil.UTF_8));			
+		ctx.writeAndFlush(httpResponse);
+		ctx.close();
+	}
+	
+	private static ChannelFuture sendResponse(ChannelHandlerContext ctx, HttpResponseStatus status) {
+		FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, status,
+				Unpooled.copiedBuffer("".toString(), CharsetUtil.UTF_8));			
+		return ctx.writeAndFlush(httpResponse);    	
+	}
+	
+	
+	private static ChannelFuture sendResponseWithContent(ChannelHandlerContext ctx, String content, HttpResponseStatus status) {
+		FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, status,
+				Unpooled.copiedBuffer(content.toString(), CharsetUtil.UTF_8));			
+		return ctx.writeAndFlush(httpResponse);    	
+	}
+	
+	private static class HttpExecutedCallback implements ExecutedCallback {
+
+		ChannelHandlerContext ctx;
+		
+		HttpExecutedCallback(ChannelHandlerContext ctx){
+			this.ctx = ctx;
+		}
+		
+		@Override
+		public void executed(Request response, boolean handled) {
+			// System.out.println("Handled: "+handled+", Response: "+response);
+			if (!handled) {
+				sendResponseAndCloseConnection(ctx);
+			}
+			ChannelFuture channelFuture = sendResponseWithContent(ctx, 
+					((HttpActiveReplicaRequest) response).response != null? ((HttpActiveReplicaRequest) response).response : response.toString(), 
+							OK);
+			channelFuture.addListener(ChannelFutureListener.CLOSE);
+		}
+		
+	}
+	
+	@SuppressWarnings("unused")
+	private static Object getValueFromKey(JSONObject json, String key) throws JSONException {
+		if (json.has(key)) {
+			return json.get(key);
+		} else if (json.has(key.toLowerCase())) {
+			return json.get(key.toLowerCase());
+		} 
+		return null;
+	}
+	
+	private static class HttpActiveReplicaHandler extends
+		SimpleChannelInboundHandler<Object> {
+
+		ActiveReplicaFunctions arFunctions;
+		final InetSocketAddress senderAddr;
+		
+		HttpActiveReplicaHandler(ActiveReplicaFunctions arFunctions, InetSocketAddress addr) {
+			this.arFunctions = arFunctions;
+			this.senderAddr = addr;
+		}
+		
+		@Override
+		protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+			if (!(msg instanceof HttpContent) || !(msg instanceof HttpRequest)) {
+				log.log(Level.FINE, "Unrecognized request: {0}", new Object[] { msg });
+			}
+			
+			HttpRequest httpRequest = (HttpRequest) msg;
+			
+			HttpMethod method = httpRequest.method();
+			
+			HttpContent httpContent = (HttpContent) msg;
+			
+			if (HttpMethod.GET.equals(method)) {
+				ChannelFuture channelFuture = sendResponse(ctx, OK);
+				channelFuture.addListener(ChannelFutureListener.CLOSE);
+			} else if (HttpMethod.POST.equals(method)) {
+				
+			} else {
+				log.log(Level.FINE, "Unsupported operation: {0}", new Object[]{ method });
+				return;
+			}
+			
+		    HttpResponseStatus status = OK;
+		    // If decoded unsuccessfully, return immediately
+		    if ( !httpContent.decoderResult().isSuccess() ) {
+		    	sendResponseAndCloseConnection(ctx);
+		    	return;
+		    }
+		    
+		    // Construct the request
+		    JSONObject json = getJSONObjectFromHttpContent(httpContent);
+		    if (json == null) {
+		    	// bad json request
+		    	sendResponseAndCloseConnection(ctx);
+		    	return;
+		    }
+		    
+ 			/** 
+ 			 * Packet type should not rely on 
+ 			 * the underlying app for the http front end. It must be a general
+ 			 * purpose request so that it can go through the whole GigaPaxos
+ 			 * protocol stack.
+ 			 */
+		    
+		    Request request = new HttpActiveReplicaRequest(json); 
+		    // System.out.println("<<<<<<<<<<<<<<<<<<<<<<< REQUEST:"+ReplicableClientRequest.wrap(request));				    
+		    		
+		    /*
+		     * If sync is false, callback is not necessary. 
+		     * Since request has been processed correctly until here, so we send back a 
+		     * OK response to let the client know.
+		     * Otherwise, we need to create a callback to send back a response to client.
+		     */
+		    boolean sync = json.has(SYNC_KEY)? json.getBoolean(SYNC_KEY): true;
+		    
+		    // System.out.println("SYNC key:"+ActiveReplicaHTTPKeys.SYNC.toString()+", sync:"+sync);
+		    
+		    ExecutedCallback callback = null;
+		    if (sync){
+		    	// callback to send back http response
+		    	callback = new HttpExecutedCallback(ctx);
+		    }
+		    
+		    boolean handled = false;
+		    			
+			// execute coordinated request here				
+			if (arFunctions != null) { 
+				log.log(Level.FINE, "App {0} executes request: {1}", new Object[]{ arFunctions, request });
+				handled = arFunctions.handRequestToAppForHttp(
+						ReplicableClientRequest.wrap(request), 
+						callback);
+			}							
+			
+			if (!handled){
+				status = BAD_REQUEST;
+			} else {
+				arFunctions.updateDemandStatsFromHttp(request, senderAddr.getAddress() );
+			}
+			
+			if (!sync) {
+				// If not synchronized, send back response
+				ChannelFuture channelFuture = sendResponse(ctx, status);
+				channelFuture.addListener(ChannelFutureListener.CLOSE);
+			}
+			
+		}
+	}
+	
+	/**
+	 * @param args
+	 * @throws CertificateException
+	 * @throws SSLException
+	 * @throws InterruptedException
+	 */
+	public static void main(String[] args) throws CertificateException, SSLException, InterruptedException {
+		new HttpActiveReplica(null, new InetSocketAddress(12416), false); 
+	}
+	
+}

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaApp.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaApp.java
@@ -1,0 +1,183 @@
+package edu.umass.cs.reconfiguration.http;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import edu.umass.cs.gigapaxos.interfaces.AppRequestParserBytes;
+import edu.umass.cs.gigapaxos.interfaces.ClientMessenger;
+import edu.umass.cs.gigapaxos.interfaces.Replicable;
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+import edu.umass.cs.nio.interfaces.SSLMessenger;
+import edu.umass.cs.nio.nioutils.NIOHeader;
+import edu.umass.cs.reconfiguration.examples.AbstractReconfigurablePaxosApp;
+import edu.umass.cs.reconfiguration.examples.AppRequest;
+import edu.umass.cs.reconfiguration.examples.AppRequest.ResponseCodes;
+import edu.umass.cs.reconfiguration.interfaces.Reconfigurable;
+import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
+
+/**
+ * @author gaozy
+ *
+ * A no-op example app for HttpActiveReplica
+ */
+public class HttpActiveReplicaApp extends AbstractReconfigurablePaxosApp<String>
+	implements Replicable, Reconfigurable, ClientMessenger, AppRequestParserBytes {
+	
+	private boolean verbose = false;
+	
+	private String myID; // used only for pretty printing
+	private final HashMap<String, AppData> appData = new HashMap<String, AppData>();
+	
+	/**
+	 * 
+	 */
+	public HttpActiveReplicaApp(){		
+	}
+	
+	private class AppData {
+		final String name;
+		String state = "";
+
+		AppData(String name, String state) {
+			this.name = name;
+			this.state = state;
+		}
+
+		void setState(String state) {
+			this.state = state;
+		}
+
+		String getState() {
+			return this.state;
+		}
+	}
+	
+	@Override
+	public boolean execute(Request request, boolean doNotReplyToClient) {
+		if (request.toString().equals(Request.NO_OP))
+			return true;
+		switch ((AppRequest.PacketType) (request.getRequestType())) {
+		case DEFAULT_APP_REQUEST:
+		case APP_REQUEST3:
+		case ADMIN_APP_REQUEST:
+			return processRequest((AppRequest) request, doNotReplyToClient);
+		default:
+			// everything else is an absolute no-op
+			break;
+		}
+		return false;
+	}
+	
+	private boolean processRequest(AppRequest request,
+			boolean doNotReplyToClient) {
+		if (request.getServiceName() == null)
+			return true; // no-op
+		if (request.isStop())
+			return true;
+		AppData data = this.appData.get(request.getServiceName());
+		if (data == null) {
+			System.out.println("App-" + myID + " has no record for "
+					+ request.getServiceName() + " for " + request);
+			assert (request.getResponse() == null);
+			return false;
+		}
+		assert (data != null);
+		data.setState(request.getValue());
+		this.appData.put(request.getServiceName(), data);
+		if (verbose)
+			System.out.println("App-" + myID + " wrote to " + data.name
+					+ " with state " + data.getState());
+		
+		request.setResponse(ResponseCodes.ACK.toString());
+		
+		return true;
+	}
+
+	
+	@Override
+	public boolean execute(Request request) {
+		return this.execute(request, false);
+	}
+
+
+	@Override
+	public String checkpoint(String name) {
+		AppData data = this.appData.get(name);
+		return data != null ? data.getState() : null;
+	}
+
+	@Override
+	public boolean restore(String name, String state) {
+		AppData data = this.appData.get(name);
+
+		// if no previous state, this is a creation epoch.
+		if (data == null && state != null) {
+			data = new AppData(name, state);
+			if (verbose)
+				System.out.println(">>>App-" + myID + " creating " + name
+						+ " with state " + state);
+		}
+		// if state==null => end of epoch
+		else if (state == null) {
+			if (data != null)
+				if (verbose)
+					System.out.println("App-" + myID + " deleting " + name
+							+ " with final state " + data.state);
+			this.appData.remove(name);
+			assert (this.appData.get(name) == null);
+		} 
+		// typical reconfiguration or epoch change
+		else if (data != null && state != null) {
+			System.out.println("App-" + myID + " updating " + name
+					+ " with state " + state);
+			data.state = state;
+		} 
+		else
+			// do nothing when data==null && state==null
+			;
+		if (state != null)
+			this.appData.put(name, data);
+
+		return true;
+	}
+
+    @Override
+    public Request getRequest(String s) throws RequestParseException {
+        try {
+            return new HttpActiveReplicaRequest(new JSONObject(s));
+        } catch (JSONException e) {
+            throw new RequestParseException(e);
+        }
+    }
+
+    private static HttpActiveReplicaPacketType[] types = HttpActiveReplicaPacketType.values();
+
+    @Override
+    public Set<IntegerPacketType> getRequestTypes() {
+        return new HashSet<>(Arrays.asList(types));
+    }
+
+
+	@Override
+	public Request getRequest(byte[] bytes, NIOHeader header) throws RequestParseException {
+		try {
+            return new HttpActiveReplicaRequest(new JSONObject(new String(bytes, NIOHeader.CHARSET)));
+        } catch (JSONException | UnsupportedEncodingException e) {
+            throw new RequestParseException(e);
+        }
+	}
+
+
+	@Override
+	public void setClientMessenger(SSLMessenger<?, JSONObject> messenger) {
+		// no need to use a messenger to send back response to client
+		this.myID = messenger.getMyID().toString();
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaApp.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaApp.java
@@ -63,19 +63,11 @@ public class HttpActiveReplicaApp extends AbstractReconfigurablePaxosApp<String>
 	public boolean execute(Request request, boolean doNotReplyToClient) {
 		if (request.toString().equals(Request.NO_OP))
 			return true;
-		switch ((AppRequest.PacketType) (request.getRequestType())) {
-		case DEFAULT_APP_REQUEST:
-		case APP_REQUEST3:
-		case ADMIN_APP_REQUEST:
-			return processRequest((AppRequest) request, doNotReplyToClient);
-		default:
-			// everything else is an absolute no-op
-			break;
-		}
-		return false;
+		
+		return processRequest((HttpActiveReplicaRequest) request, doNotReplyToClient);
 	}
 	
-	private boolean processRequest(AppRequest request,
+	private boolean processRequest(HttpActiveReplicaRequest request,
 			boolean doNotReplyToClient) {
 		if (request.getServiceName() == null)
 			return true; // no-op

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
@@ -14,14 +14,6 @@ public enum HttpActiveReplicaPacketType implements IntegerPacketType {
 	 * For underlying app to execute
 	 */
 	EXECUTE(400),
-	/**
-	 * For underlying app to checkpoint a snapshot, not for the {@link Replicable} checkpoint
-	 */
-	SNAPSHOT(401),
-	/**
-	 * For underlying app to recover to the most recent state, not for the {@link Replicable} restore
-	 */
-	RECOVER(402),
 	;
 
 	/**

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
@@ -1,12 +1,9 @@
 package edu.umass.cs.reconfiguration.http;
 
-import edu.umass.cs.nio.interfaces.IntegerPacketType;
-
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
 
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
 
 /**
  * @author gaozy

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaPacketType.java
@@ -1,0 +1,71 @@
+package edu.umass.cs.reconfiguration.http;
+
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import edu.umass.cs.gigapaxos.interfaces.Replicable;
+
+/**
+ * @author gaozy
+ *
+ */
+public enum HttpActiveReplicaPacketType implements IntegerPacketType {
+	/**
+	 * For underlying app to execute
+	 */
+	EXECUTE(400),
+	/**
+	 * For underlying app to checkpoint a snapshot, not for the {@link Replicable} checkpoint
+	 */
+	SNAPSHOT(401),
+	/**
+	 * For underlying app to recover to the most recent state, not for the {@link Replicable} restore
+	 */
+	RECOVER(402),
+	;
+
+	/**
+	 * 
+	 */
+	private static HashMap<Integer, HttpActiveReplicaPacketType> numbers = new HashMap<>();
+	static {
+		for (HttpActiveReplicaPacketType type : HttpActiveReplicaPacketType.values()) {
+			if (!numbers.containsKey(type.number))
+				numbers.put(type.number, type);
+		}
+	}
+	
+	/**
+	 * @param t
+	 * @return HttpPacketType
+	 */
+	public static HttpActiveReplicaPacketType getPacketType(int t) {
+		return numbers.get(t);
+	}
+	
+	@Override
+	public int getInt() {
+		return this.number;
+	}
+
+	private final int number;
+	
+	HttpActiveReplicaPacketType(int number){
+		this.number = number;
+	}
+	
+	/**
+	 * Test
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		HttpActiveReplicaPacketType type = HttpActiveReplicaPacketType.EXECUTE;
+		assert(type == getPacketType(type.number));
+		
+		int n = 503;
+		assert(getPacketType(n) == null);
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaRequest.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplicaRequest.java
@@ -1,0 +1,232 @@
+package edu.umass.cs.reconfiguration.http;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
+import edu.umass.cs.nio.JSONPacket;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
+import edu.umass.cs.reconfiguration.interfaces.ReplicableRequest;
+
+/**
+ * HttpRequest is the type of request used by {@link HttpActiveReplica}.
+ * All the applications that need to use {@link HttpActiveReplica} must
+ * follow the spec of this class (HttpRequest).
+ *
+ * HttpRequest requires the content of a HTTP POST request (to
+ * {@link HttpActiveReplica} ) in JSON format.
+ * It must contains the following keys: NAME, VALUE, and SYNC
+ * 
+ * The key PACKET_TYPE of {@link JSONPacket}.
+ *
+ * @author gaozy
+ *
+ */
+
+public class HttpActiveReplicaRequest extends JSONPacket implements 
+	ReplicableRequest, ReconfigurableRequest, ClientRequest {
+	
+	/**
+	 * Keys of HttpRequest
+	 *
+	 */
+	public static enum Keys{
+		/**
+		 * The service name that must present in every request.
+		 */
+		NAME,
+		
+		/**
+		 * Request value
+		 */
+		QVAL,
+		
+		/**
+		 * Request id
+		 */
+		QID,
+		
+		/**
+		 * Response value
+		 */
+		RVAL,
+		
+		/**
+		 * Coordinated or not
+		 */
+		COORD,
+	};
+	
+	private final String name;
+	private final long id;
+	private final String value;
+	private final boolean coord;
+	
+	/**
+	 * Response from underlying app
+	 */
+	public String response;
+	
+	/**
+	 * HttpRequest is request type agnostic, the underlying application needs 
+	 * to define their own types if necessary.
+	 * 
+	 * @param t
+	 * @param name
+	 * @param id 
+	 * @param value 
+	 * @param coord 
+	 */
+	public HttpActiveReplicaRequest(IntegerPacketType t, String name, long id, String value, boolean coord) {
+		super(t);
+		this.name = name;
+		this.id = id;
+		this.value = value;
+		this.coord = coord;
+	}
+	
+	
+	/**
+	 * By default, sync is false, i.e., HTTP response can be sent back before app executes the request
+	 * 
+	 * @param t
+	 * @param name
+	 * @param id
+	 * @param value
+	 */
+	public HttpActiveReplicaRequest(IntegerPacketType t, String name, long id, String value){
+		this(t, name, id, value, true);
+	}
+	
+	/**
+	 * If no ID presents, we may generate an ID for the request.
+	 * 
+	 * @param t
+	 * @param name
+	 * @param value
+	 */
+	public HttpActiveReplicaRequest(IntegerPacketType t, String name, String value){
+		this(t, name, (int) (Math.random() * Integer.MAX_VALUE), value, true);
+	}
+		
+	/**
+	 * @param value
+	 * @param req
+	 */
+	public HttpActiveReplicaRequest(String value, HttpActiveReplicaRequest req) {
+		this(HttpActiveReplicaPacketType.getPacketType(req.type), req.name, req.id, value, req.coord);
+	}
+	
+	/**
+	 * @param json
+	 * @throws JSONException
+	 */
+	public HttpActiveReplicaRequest(JSONObject json) throws JSONException{
+		// get request type
+		super(json);
+		
+		Object obj = getValueFromJSONCaseInsensitive(Keys.NAME.toString(), json);		
+		this.name = obj==null? null : (String) obj;
+		
+		obj = getValueFromJSONCaseInsensitive(Keys.QVAL.toString(), json);
+		this.value = obj==null? null : (String) obj;
+		
+		obj = getValueFromJSONCaseInsensitive(Keys.QID.toString(), json);
+		this.id = obj==null? (int) (Math.random() * Integer.MAX_VALUE): Long.parseLong(String.valueOf(obj));
+		
+		obj = getValueFromJSONCaseInsensitive(Keys.COORD.toString(), json);
+		this.coord = obj==null? false: (Boolean) obj;
+		
+		obj = getValueFromJSONCaseInsensitive(Keys.RVAL.toString(), json);
+		this.response = obj==null? null: (String) obj;
+	}
+	
+	private Object getValueFromJSONCaseInsensitive(String key, JSONObject json) throws JSONException {
+		if (json.has(key)) {
+			return json.get(key);
+		} else if (json.has(key.toLowerCase())) {
+			return json.get(key.toLowerCase());
+		}
+		return null;
+	}
+	
+	@Override
+	protected JSONObject toJSONObjectImpl() throws JSONException {
+		JSONObject json = new JSONObject();
+		json.put(Keys.NAME.toString(), this.name);
+		json.put(Keys.QVAL.toString(), this.value);
+		json.put(Keys.COORD.toString(), this.coord);
+		json.put(Keys.QID.toString(), this.id);
+		// json.put("STOP", false);
+		// json.put("EPOCH", 0);
+		json.putOpt(Keys.RVAL.toString(), this.response);
+		return json;
+	}
+	
+	@Override
+	public IntegerPacketType getRequestType() {
+		return HttpActiveReplicaPacketType.getPacketType(this.type);
+	}
+
+	@Override
+	public String getServiceName() {
+		return this.name;
+	}
+
+	@Override
+	public long getRequestID() {
+		return this.id;
+	}
+	
+	/**
+	 * @return value
+	 */
+	public String getValue() {
+		return this.value;
+	}
+	
+	@Override
+	public boolean needsCoordination() {
+		// every HttpRequest needs coordination
+		return this.coord;
+	}
+	
+	@Override
+	public int getEpochNumber() {
+		return 0;
+	}
+
+	/**
+	 * Always not a stop request
+	 */
+	@Override
+	public boolean isStop() {
+		return false;
+	}
+
+	/**
+	 * @param response
+	 */
+	public void setResponse(String response) {
+		this.response = response;
+	}
+
+	@Override
+	public ClientRequest getResponse() {
+		if (this.response != null)
+			return new HttpActiveReplicaRequest(this.response, this);
+		return null;
+	}
+	
+	
+	/**
+	 * Test request serialization.
+	 * 
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		
+	}
+
+}

--- a/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
@@ -439,6 +439,7 @@ public class HttpReconfigurator {
 				try {
 					JSONObject json = toJSONObject(new QueryStringDecoder(
 							request.uri()).parameters());
+					log.log(Level.INFO, "JSON converted from uri is {0}", new Object[] { json });
 					crp = toReconfiguratorRequest(json, ctx.channel());
 					
 					System.out.println(crp);

--- a/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
@@ -183,7 +183,7 @@ public class HttpReconfigurator {
 			InetSocketAddress sockAddr, boolean ssl)
 			throws CertificateException, SSLException, InterruptedException {
 
-		this.rcf = rcf.toString();
+		this.rcf = rcf==null? "": rcf.toString();
 
 		// Configure SSL.
 		final SslContext sslCtx;
@@ -442,7 +442,7 @@ public class HttpReconfigurator {
 					crp = toReconfiguratorRequest(json, ctx.channel());
 					
 					System.out.println(crp);
-					
+					if (rcFunctions != null)
 					crp = (ReconfiguratorRequest) this.rcFunctions
 							.sendRequest(crp);
 					buf.append(crp.toString());

--- a/src/edu/umass/cs/reconfiguration/interfaces/ActiveReplicaFunctions.java
+++ b/src/edu/umass/cs/reconfiguration/interfaces/ActiveReplicaFunctions.java
@@ -1,0 +1,30 @@
+package edu.umass.cs.reconfiguration.interfaces;
+
+import java.net.InetAddress;
+
+import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.reconfiguration.ActiveReplica;
+
+/**
+ * A minimal interface defining active replica server functions. This
+ * interface is implemented by {@link ActiveReplica}.
+ * 
+ * @author gaozy
+ *
+ */
+public interface ActiveReplicaFunctions {
+	
+	/**
+	 * @param request 
+	 * @param callback 
+	 * @return true if request is executed successfully
+	 */
+	public boolean handRequestToAppForHttp(Request request, ExecutedCallback callback);
+
+	/**
+	 * @param request
+	 * @param addr
+	 */
+	public void updateDemandStatsFromHttp(Request request, InetAddress addr);
+}

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/CreateServiceName.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/CreateServiceName.java
@@ -296,9 +296,11 @@ public class CreateServiceName extends ClientReconfigurationPacket {
 		this.initGroup = json.has(Keys.INIT_GROUP.toString()) ? Util
 				.getSocketAddresses(json.getJSONArray(Keys.INIT_GROUP
 						.toString())) : null;
-		this.policy = ReconfigurationConfig.ReconfigureUponActivesChange
+		this.policy = json.has(Keys.RECONFIGURE_UPON_ACTIVES_CHANGE.toString()) ?
+				ReconfigurationConfig.ReconfigureUponActivesChange
 				.valueOf(json.getString(Keys.RECONFIGURE_UPON_ACTIVES_CHANGE
-						.toString()));
+						.toString()))
+				:ReconfigurationConfig.getDefaultReconfigureUponActivesChangePolicy();
 	}
 
 	/**


### PR DESCRIPTION
This pull request contains the following changes:

1. An HTTP front-end that follows a similar implementation as HttpReconfigurator: HttpActiveReplica
2. An interface called ActiveReplicaFunctions for ActiveReplica to implement, so that HttpActiveReplica can send requests to GigaPaxos for coordination and send demand profiles to RC
3. ActiveReplica which implements ActiveReplicaFunctions initializes a HttpActiveReplica and passes itself as a reference to the HttpActiveReplica.
4. HttpActiveReplicaRequest is implemented for all applications that need to use HttpActiveReplica
5. A demo app called HttpActiveReplicaApp is implemented to demonstrate how to use HttpActiveReplica
6. A config file called conf/example/http.properties used by GigaPaxos HTTP tutorial
7. Fix a bug in CreateServiceName whose JSON constructor does not check whether a policy exists.
8. Fix some minor issues in HttpReconfigurator: check whether the variable rtf is null before being used.