### PR TITLE
Add a DNS traffic policy interface

### DIFF
--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -378,9 +378,19 @@ public class ReconfigurationConfig {
 		HTTP_PORT_SSL_OFFSET(400),
 		
 		/**
-		 * Enable DnsReconfigurator, which needs admin priviledge to bind to port 53
+		 * Enable DnsReconfigurator, which needs admin privilege to bind to port 53
 		 */
 		ENABLE_RECONFIGURATOR_DNS (false),
+		
+		/**
+		 * The default ttl value used by DnsReconfigurator
+		 */
+		DEFAULT_DNS_TTL(30),
+		
+		/**
+		 * The default traffic policy class used by DnsReconfigurator
+		 */
+		DEFAULT_DNS_TRAFFIC_POLICY_CLASS("edu.umass.cs.reconfiguration.dns.NoopDnsTrafficPolicy"),
 		
 		/**
 		 * Enable the HTTP server for reconfigurators.

--- a/src/edu/umass/cs/reconfiguration/dns/DnsTrafficPolicy.java
+++ b/src/edu/umass/cs/reconfiguration/dns/DnsTrafficPolicy.java
@@ -1,0 +1,22 @@
+package edu.umass.cs.reconfiguration.dns;
+
+import java.net.InetAddress;
+import java.util.Set;
+
+/**
+ * Interface to 
+ * 
+ * @author gaozy
+ *
+ */
+public interface DnsTrafficPolicy {
+	
+	/**
+	 *  
+	 * @param addresses
+	 * @param source
+	 * @return a new set of addresses generated from original set of available addresses
+	 */
+	public Set<InetAddress> getAddresses(Set<InetAddress> addresses, InetAddress source);
+	
+}

--- a/src/edu/umass/cs/reconfiguration/dns/NoopDnsTrafficPolicy.java
+++ b/src/edu/umass/cs/reconfiguration/dns/NoopDnsTrafficPolicy.java
@@ -1,0 +1,17 @@
+package edu.umass.cs.reconfiguration.dns;
+
+import java.net.InetAddress;
+import java.util.Set;
+
+/**
+ * @author gaozy
+ *
+ */
+public class NoopDnsTrafficPolicy implements DnsTrafficPolicy {
+
+	@Override
+	public Set<InetAddress> getAddresses(Set<InetAddress> addresses, InetAddress source) {
+		// return original address set without modification 
+		return addresses;
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/dns/RandomDnsTrafficPolicy.java
+++ b/src/edu/umass/cs/reconfiguration/dns/RandomDnsTrafficPolicy.java
@@ -1,0 +1,26 @@
+package edu.umass.cs.reconfiguration.dns;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * @author gaozy
+ *
+ */
+public class RandomDnsTrafficPolicy implements DnsTrafficPolicy {
+	
+	private static Random rand = new Random();
+	
+	@Override
+	public Set<InetAddress> getAddresses(Set<InetAddress> addresses, InetAddress source) {
+		// return a random address from the original address set
+		Set<InetAddress> result = new HashSet<InetAddress>();
+		List<InetAddress> targetList = new ArrayList<>(addresses);
+		result.add(targetList.get(rand.nextInt(targetList.size())));
+		return result;
+	}
+}


### PR DESCRIPTION
This pull request contains the following changes:
1. A DNS traffic policy interface: edu.umass.cs.reconfiguration.dns.DnsTrafficPolicy
2. Two classes implement DnsTrafficPolicy interface: NoopDnsTrafficPolicy and RandomDnsTrafficPolicy
3. Add two options in ReconfigurationOption: DEFAULT_DNS_TTL and DEFAULT_DNS_TRAFFIC_POLICY_CLASS