### PR TITLE
Change oraclejdk8 to openjdk8 for travis ci test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 # sudo: required instructs Travis to use a "real VM" instead of a docker VM
 sudo: required
 jdk:
-- oraclejdk8
+- openjdk8
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq ant-optional


### PR DESCRIPTION
Based on the post(https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365), Travis CI migrates its image from Trusty to Xenial, which does not support oraclejdk8 anymore. So change oraclejdk8 to openjdk8 to make auto test with Travis CI will still work in the future. 