### PR TITLE
Add a feature to HttpReconfigurator for service creation with initial state through HTTP APIs

### DIFF
--- a/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
@@ -394,6 +394,10 @@ public class HttpReconfigurator {
 
 		;
 
+		if (json.has(HTTPKeys.INITIAL_STATE.label)) {
+			json.put(HTTPKeys.INITIAL_STATE.label, json.getString(HTTPKeys.INITIAL_STATE.label));
+		}
+
 		ClientReconfigurationPacket crp;
 		try {
 			crp = (ClientReconfigurationPacket) ReconfigurationPacket

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/ClientReconfigurationPacket.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/ClientReconfigurationPacket.java
@@ -131,6 +131,8 @@ public abstract class ClientReconfigurationPacket extends
 	// creation time of this request
 	private long createTime = System.currentTimeMillis();
 	private ResponseCodes responseCode = null;
+	// initial state
+	private String state = null;
 
 	/**
 	 * @param initiator
@@ -234,6 +236,9 @@ public abstract class ClientReconfigurationPacket extends
 
 		this.responseCode = json.has(Keys.RESPONSE_CODE.toString()) ? ResponseCodes
 				.valueOf(json.getString(Keys.RESPONSE_CODE.toString())) : null;
+
+		this.state = json.has(Keys.INITIAL_STATE.toString())?
+				json.getString(Keys.INITIAL_STATE.toString()) : null;
 	}
 
 	/**

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/CreateServiceName.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/CreateServiceName.java
@@ -282,7 +282,11 @@ public class CreateServiceName extends ClientReconfigurationPacket {
 		super(json, CreateServiceName.unstringer); // ignores unstringer
 		// may not be true for String packet demultiplexers
 		// assert (this.getSender() != null);
-		this.initialState = json.optString(Keys.STATE.toString(), null);
+		this.initialState = json.has(Keys.STATE.toString())?
+				json.getString(Keys.STATE.toString()) :
+				json.has(ClientReconfigurationPacket.Keys.INITIAL_STATE.toString())?
+						json.getString(ClientReconfigurationPacket.Keys.INITIAL_STATE.toString()) : null;
+		// json.optString(Keys.STATE.toString(), null);
 		this.nameStates = getNameStateMap(json);
 		JSONArray jsonArray = json.has(Keys.FAILED_CREATES.toString()) ? json
 				.getJSONArray(Keys.FAILED_CREATES.toString()) : null;


### PR DESCRIPTION
 Add a feature to HttpReconfigurator that allows customers to create a service name with an initial state using HTTP APIs.