### PR TITLE
Remove unused imports that cause compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build.number
 /jars/
 .idea/*
 *.iml
+/output
+/out

--- a/src/edu/umass/cs/gigapaxos/examples/adder/StatefulAdderAppClient.java
+++ b/src/edu/umass/cs/gigapaxos/examples/adder/StatefulAdderAppClient.java
@@ -2,7 +2,6 @@ package edu.umass.cs.gigapaxos.examples.adder;
 
 import edu.umass.cs.gigapaxos.PaxosClientAsync;
 import edu.umass.cs.gigapaxos.PaxosConfig;
-import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
 import edu.umass.cs.gigapaxos.interfaces.Request;
 import edu.umass.cs.gigapaxos.interfaces.RequestCallback;
 import edu.umass.cs.gigapaxos.paxospackets.RequestPacket;

--- a/src/edu/umass/cs/gigapaxos/examples/noop/NoopPaxosAppClient.java
+++ b/src/edu/umass/cs/gigapaxos/examples/noop/NoopPaxosAppClient.java
@@ -1,15 +1,13 @@
 package edu.umass.cs.gigapaxos.examples.noop;
 
-import java.io.IOException;
-
+import edu.umass.cs.gigapaxos.PaxosClientAsync;
+import edu.umass.cs.gigapaxos.PaxosConfig;
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.gigapaxos.interfaces.RequestCallback;
 import edu.umass.cs.gigapaxos.paxospackets.RequestPacket;
 import org.json.JSONException;
 
-import edu.umass.cs.gigapaxos.PaxosClientAsync;
-import edu.umass.cs.gigapaxos.PaxosConfig;
-import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
-import edu.umass.cs.gigapaxos.interfaces.Request;
-import edu.umass.cs.gigapaxos.interfaces.RequestCallback;
+import java.io.IOException;
 
 /**
  * @author arun

--- a/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
@@ -15,20 +15,6 @@
  * Initial developer(s): V. Arun */
 package edu.umass.cs.reconfiguration;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.net.InetSocketAddress;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
-
-import edu.umass.cs.nio.interfaces.Stringifiable;
-import edu.umass.cs.reconfiguration.interfaces.ReplicaCoordinator;
-import jdk.nashorn.internal.runtime.regexp.joni.constants.NodeType;
-import org.json.JSONObject;
-
 import edu.umass.cs.gigapaxos.AbstractPaxosLogger;
 import edu.umass.cs.gigapaxos.PaxosConfig;
 import edu.umass.cs.gigapaxos.PaxosConfig.PC;
@@ -46,6 +32,15 @@ import edu.umass.cs.reconfiguration.reconfigurationutils.DefaultNodeConfig;
 import edu.umass.cs.reconfiguration.reconfigurationutils.ReconfigurationPacketDemultiplexer;
 import edu.umass.cs.reconfiguration.reconfigurationutils.ReconfigurationPolicyTest;
 import edu.umass.cs.utils.Config;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
 
 /**
  * 

--- a/src/edu/umass/cs/reconfiguration/examples/linwrites/LinWritesLocReadsAppClient.java
+++ b/src/edu/umass/cs/reconfiguration/examples/linwrites/LinWritesLocReadsAppClient.java
@@ -90,7 +90,7 @@ public class LinWritesLocReadsAppClient extends
 							makeWriteRequest(),
 
 					// to redirect request to specific active replica
-					//new InetSocketAddress("localhost", 8001),
+					// new InetSocketAddress("localhost", 8001),
 
 					new Callback<Request, SimpleAppRequest>() {
 						long createTime = System.currentTimeMillis();


### PR DESCRIPTION
I followed the getting started documentation (`ant jar`) and get the following error:
```
gigapaxos/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java:29: error: package jdk.nashorn.internal.runtime.regexp.joni.constants does not exist
```

It seems like that package is never used in the code, so I remove it and it compiled successfully. I also remove unused imports in other files as well, and also adding `output` and `out` in `.gitignore`.

Changelog:
- Remove unused imports that cause a compilation error
- Add `output` and `out` directory in `.gitignore` so they won't be tracked by git.