### PR TITLE
Helper Methods to Identify Current Coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 build.number
 /build/
 /dist/
+/output
+/out
 /derby.log
 /paxos_logs/
 /reconfiguration_DB/

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 build.number
 /build/
 /dist/
-/output
-/out
 /derby.log
 /paxos_logs/
 /reconfiguration_DB/

--- a/src/edu/umass/cs/gigapaxos/PaxosInstanceStateMachine.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosInstanceStateMachine.java
@@ -2642,4 +2642,25 @@ private String getBallots() {
 		return (int) (cpi * (1 - CPI_NOISE) + (Math.abs(paxosID.hashCode()) % cpi)
 				* 2 * CPI_NOISE);
 	}
+
+	/**
+	 * isPaxosCoordinator returns a boolean indicating whether this state
+	 * machine replica is a paxos coordinator or not. This method should
+	 * only be used by PaxosManager.
+	 * @return true if this replica is a paxos coordinator.
+	 */
+	protected boolean isPaxosCoordinator() {
+		return PaxosCoordinator.exists(
+				this.coordinator, this.paxosState.getBallot());
+	}
+
+	/**
+	 * getCurrentPaxosCoordinator returns an integer ID of the current
+	 * perceived coordinator. This method should only be used by PaxosManager.
+	 * @return the integer ID of the currently perceived coordinator.
+	 */
+	protected int getCurrentPaxosCoordinator() {
+		return this.paxosState.getBallotCoord();
+	}
+
 }

--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -3495,4 +3495,42 @@ public class PaxosManager<NodeIDType> {
 			rc.setAcceptPacket(accept);
 		return accept;
 	}
+
+	/**
+	 * isPaxosCoordinator returns true if the paxos instance that live in this
+	 * node (i.e., ActiveReplica) think itself is the current paxos coordinator.
+	 * Note that, due to asynchrony, it is possible that multiple nodes think
+	 * itself as an active coordinator.
+	 * @param serviceName the name of service (or object) being replicated.
+	 * @return true if the paxos instanace in this node think itself as
+	 *  a paxos coordinator.
+	 */
+	public boolean isPaxosCoordinator(String serviceName) {
+		// use getInstance() method, instead of directly accessing `pinstances`,
+		// because a paused PaxosInstanceStateMachine (PISM) could be null.
+		PaxosInstanceStateMachine pism = this.getInstance(serviceName);
+		if (pism == null) {
+			return false;
+		}
+
+		return pism.isPaxosCoordinator();
+	}
+
+	/**
+	 * getPaxosCoordinator returns the node ID, which this node (Active Replica)
+	 * think as the coordinator. It is possible this node to return the ID
+	 * of itself if it thinks it is the current coordinator at the time of
+	 * executing this method.
+	 * @param serviceName the name of service (or object) being replicated.
+	 * @return the ID of the coordinator node, or null if this node does not
+	 *  know who is the current coordinator.
+	 */
+	public NodeIDType getPaxosCoordinator(String serviceName) {
+		PaxosInstanceStateMachine pism = this.getInstance(serviceName);
+		if (pism == null) {
+			return null;
+		}
+
+		return this.integerMap.get(pism.getCurrentPaxosCoordinator());
+	}
 }

--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -3520,7 +3520,8 @@ public class PaxosManager<NodeIDType> {
 	 * getPaxosCoordinator returns the node ID, which this node (Active Replica)
 	 * think as the coordinator. It is possible this node to return the ID
 	 * of itself if it thinks it is the current coordinator at the time of
-	 * executing this method.
+	 * executing this method. The returned node ID (if not null) can be used
+	 * by Messenger to send any protocol messages.
 	 * @param serviceName the name of service (or object) being replicated.
 	 * @return the ID of the coordinator node, or null if this node does not
 	 *  know who is the current coordinator.


### PR DESCRIPTION
Implemented helper methods in PISM, later used in PaxosManager, to identify whether the current node is a coordinator, and get the current coordinator.

The methods are intended for PrimaryBackupReplicaCoordinator implementation.
